### PR TITLE
Fix inline_message_id not using inlineMessageId

### DIFF
--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -173,7 +173,7 @@ class Telegram extends ApiClient {
     return this.callApi('editMessageText', Object.assign({
       chat_id: chatId,
       message_id: messageId,
-      inline_message_id: messageId,
+      inline_message_id: inlineMessageId,
       text: text
     }, extra))
   }
@@ -182,7 +182,7 @@ class Telegram extends ApiClient {
     return this.callApi('editMessageCaption', {
       chat_id: chatId,
       message_id: messageId,
-      inline_message_id: messageId,
+      inline_message_id: inlineMessageId,
       caption: caption,
       reply_markup: markup
     })
@@ -192,7 +192,7 @@ class Telegram extends ApiClient {
     return this.callApi('editMessageReplyMarkup', {
       chat_id: chatId,
       message_id: messageId,
-      inline_message_id: messageId,
+      inline_message_id: inlineMessageId,
       reply_markup: markup
     })
   }


### PR DESCRIPTION
There was an error when I used editMessageText on a context object from a callback_query update and the update came from an inline message.