### PR TITLE
Fix ignoring webhookReply option

### DIFF
--- a/lib/telegraf.js
+++ b/lib/telegraf.js
@@ -12,6 +12,7 @@ class Telegraf extends Composer {
       retryAfter: 1,
       handlerTimeout: 0
     }, options)
+    this.telegram = new Telegram(token, this.options.telegram)
     this.token = token
     this.handleError = (err) => {
       console.error()
@@ -32,7 +33,7 @@ class Telegraf extends Composer {
 
   set token (token) {
     this.options.token = token
-    this.telegram = new Telegram(this.options.token, this.options.telegram)
+    this.telegram = new Telegram(this.options.token, this.telegram.options)
   }/* eslint brace-style: 0 */
 
   catch (handler) {
@@ -96,7 +97,7 @@ class Telegraf extends Composer {
   handleUpdate (update, webhookResponse) {
     debug('⚡ update', update.update_id)
     const telegram = webhookResponse
-      ? new Telegram(this.token, this.options.telegram, webhookResponse)
+      ? new Telegram(this.token, this.telegram.options, webhookResponse)
       : this.telegram
     const ctx = new Context(update, telegram, this.options)
     Object.assign(ctx, this.context)

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -161,3 +161,17 @@ test.cb('should handle webhook response', (t) => {
   }
   app.handleUpdate({message: baseMessage}, res)
 })
+
+test.cb('should respect webhookReply option', (t) => {
+  const app = new Telegraf()
+  app.telegram.webhookReply = false
+  app.on('message', (ctx) => {
+    ctx.reply(':)')
+  })
+  const res = {
+    setHeader: () => undefined,
+    end: () => undefined
+  }
+  t.throws(app.handleUpdate({message: baseMessage}, res))
+    .then(() => t.end())
+})


### PR DESCRIPTION
When webhookReply is set by app.telegram.webhookReply and not from options passed to contructor this option is ignored. Actually, all telegram options was reverted to defaults, but only this one has get/set methods.
Steps to reproduce:
```
const Telegraf = require('telegraf')

const app = new Telegraf()

const baseMessage = {
  chat: {
    id: 1
  }
}

app.telegram.webhookReply = false

app.on('message', (ctx) => {
  ctx.reply(':)')
    .then((res) => console.log(res))
})
const res = {
  setHeader: () => undefined,
  end: () => undefined
}
app.handleUpdate({message: baseMessage}, res)

```
ctx.reply should throw because no token were provided. But instead it replies to webhook.