### PR TITLE
fix for Composer.command

### DIFF
--- a/lib/core/composer.js
+++ b/lib/core/composer.js
@@ -145,7 +145,7 @@ class Composer {
         : []
       const hasMatch = ctx.message.entities && ctx.message.entities.find((entity) => {
         const command = text.substring(entity.offset, entity.offset + entity.length)
-        return entity.type === 'bot_command' && (commands.includes(command) || groupCommands.includes(command))
+        return entity.type === 'bot_command' && entity.offset == 0 && (commands.includes(command) || groupCommands.includes(command))
       })
       return hasMatch ? middleware : Composer.passThru()
     }))

--- a/test/composer.js
+++ b/test/composer.js
@@ -466,14 +466,6 @@ test.cb('should handle short command', (t) => {
   app.handleUpdate({message: Object.assign({text: '/start', entities: [{type: 'bot_command', offset: 0, length: 6}]}, baseMessage)})
 })
 
-test.cb('should handle short command with offset', (t) => {
-  const app = new Telegraf()
-  app.command('start', (ctx) => {
-    t.end()
-  })
-  app.handleUpdate({message: Object.assign({text: 'Hey /start', entities: [{type: 'bot_command', offset: 4, length: 6}]}, baseMessage)})
-})
-
 test.cb('should handle command in group', (t) => {
   const app = new Telegraf('---', {username: 'bot'})
   app.command('start', (ctx) => {


### PR DESCRIPTION
Hello. It's me again.

I just have found out that Composer.command accept any command that is containing in a message. That's not a right way.

Look at official bots - @botfather, @telegraph. They consider a text message as a command only if it starts with a command.