### PR TITLE
get message of callback_query from ctx.message

### DIFF
--- a/lib/core/context.js
+++ b/lib/core/context.js
@@ -64,7 +64,8 @@ class TelegrafContext {
   }
 
   get message () {
-    return this.update.message
+    return this.update.message ||
+      (this.callbackQuery && this.callbackQuery.message)
   }
 
   get editedMessage () {
@@ -102,7 +103,6 @@ class TelegrafContext {
   get chat () {
     return (this.message && this.message.chat) ||
       (this.editedMessage && this.editedMessage.chat) ||
-      (this.callbackQuery && this.callbackQuery.message && this.callbackQuery.message.chat) ||
       (this.channelPost && this.channelPost.chat) ||
       (this.editedChannelPost && this.editedChannelPost.chat)
   }
@@ -163,21 +163,21 @@ class TelegrafContext {
     this.assertShortcut(this.callbackQuery, 'editMessageText')
     return this.callbackQuery.inline_message_id
       ? this.telegram.editMessageText(undefined, undefined, this.callbackQuery.inline_message_id, text, extra)
-      : this.telegram.editMessageText(this.chat.id, this.callbackQuery.message.message_id, undefined, text, extra)
+      : this.telegram.editMessageText(this.chat.id, this.message.message_id, undefined, text, extra)
   }
 
   editMessageCaption (caption, markup) {
     this.assertShortcut(this.callbackQuery, 'editMessageCaption')
     return this.callbackQuery.inline_message_id
       ? this.telegram.editMessageCaption(undefined, undefined, this.callbackQuery.inline_message_id, caption, markup)
-      : this.telegram.editMessageCaption(this.chat.id, this.callbackQuery.message.message_id, undefined, caption, markup)
+      : this.telegram.editMessageCaption(this.chat.id, this.message.message_id, undefined, caption, markup)
   }
 
   editMessageReplyMarkup (markup) {
     this.assertShortcut(this.callbackQuery, 'editMessageReplyMarkup')
     return this.callbackQuery.inline_message_id
       ? this.telegram.editMessageReplyMarkup(undefined, undefined, this.callbackQuery.inline_message_id, markup)
-      : this.telegram.editMessageReplyMarkup(this.chat.id, this.callbackQuery.message.message_id, undefined, markup)
+      : this.telegram.editMessageReplyMarkup(this.chat.id, this.message.message_id, undefined, markup)
   }
 
   reply (...args) {
@@ -362,7 +362,7 @@ class TelegrafContext {
 
   deleteMessage () {
     this.assertShortcut(this.callbackQuery, 'deleteMessage')
-    return this.telegram.deleteMessage(this.chat.id, this.callbackQuery.message.message_id)
+    return this.telegram.deleteMessage(this.chat.id, this.message.message_id)
   }
 }
 

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -2,6 +2,7 @@ const test = require('ava')
 const Telegraf = require('../')
 
 const baseMessage = {
+  id: 1337,
   chat: {
     id: 1
   }
@@ -43,6 +44,7 @@ test.cb('should provide update payload for text', (t) => {
     t.true('updateType' in ctx)
     t.true('updateSubTypes' in ctx)
     t.true('chat' in ctx)
+    t.true('message' in ctx)
     t.true('from' in ctx)
     t.true('state' in ctx)
     t.is(ctx.updateType, 'message')
@@ -167,6 +169,24 @@ test.cb('should provide chat and sender info', (t) => {
     t.end()
   })
   app.handleUpdate({message: Object.assign({from: {id: 42}}, baseMessage)})
+})
+
+test.cb('should provide message info from message', (t) => {
+  const app = new Telegraf()
+  app.on(['text', 'message'], (ctx) => {
+    t.is(ctx.message.id, 1337)
+    t.end()
+  })
+  app.handleUpdate({message: baseMessage})
+})
+
+test.cb('should provide message info from callback_query', (t) => {
+  const app = new Telegraf()
+  app.on('callback_query', (ctx) => {
+    t.is(ctx.message.id, 1337)
+    t.end()
+  })
+  app.handleUpdate({ callback_query: { message: baseMessage } })
 })
 
 test.cb('should provide shortcuts for `inline_query` event', (t) => {


### PR DESCRIPTION
As a user I would expect `ctx.message` to be filled when `this.callbackQuery.message` contains a message.
It should be the same as for example `ctx.chat` which is filled with `ctx.callbackQuery.message.chat` when available.
