### PR TITLE
bugfix(stage): It was not possible to add a listener after registering the middleware

### DIFF
--- a/stage.js
+++ b/stage.js
@@ -28,7 +28,7 @@ class Stage extends Composer {
         ctx.scene = new SceneContext(ctx, this.scenes, this.options)
         return next()
       },
-      super.middleware(),
+      lazy((ctx) => super.middleware()),
       lazy((ctx) => ctx.scene.current || safePassThru())
     ])
     return optional((ctx) => ctx[this.options.sessionName], handler)


### PR DESCRIPTION
It was not possible to add a listener after registering the middleware