### PR TITLE
Avoiding empty undefined properties

### DIFF
--- a/extra.js
+++ b/extra.js
@@ -36,12 +36,15 @@ class Extra {
   }
 
   HTML (value = true) {
-    this.parse_mode = value ? 'HTML' : undefined
-    return this
+    return value ? this._setParseMode('HTML') : this
   }
 
   markdown (value = true) {
-    this.parse_mode = value ? 'Markdown' : undefined
+    return value ? this._setParseMode('Markdown') : this
+  }
+
+  _setParseMode (mode) {
+    this.parse_mode = mode
     return this
   }
 


### PR DESCRIPTION
We can avoid next behavior with this fix:
```
> o = {}
< {}
> o.p = undefined
< undefined
> o
< {p: undefined}
```
