### PR TITLE
Strange endless loop happening here

### DIFF
--- a/telegraf.js
+++ b/telegraf.js
@@ -140,7 +140,7 @@ class Telegraf extends Composer {
       .catch((err) => {
         console.error('Failed to process updates.', err)
         this.polling.started = false
-        this.polling.offset = 0
+        this.polling.offset = 1 //avoid endless loop
         this.polling.stopCallback && this.polling.stopCallback()
         return []
       })

--- a/telegraf.js
+++ b/telegraf.js
@@ -140,7 +140,7 @@ class Telegraf extends Composer {
       .catch((err) => {
         console.error('Failed to process updates.', err)
         this.polling.started = false
-        this.polling.offset = 1 //avoid endless loop
+        this.polling.offset = 1
         this.polling.stopCallback && this.polling.stopCallback()
         return []
       })


### PR DESCRIPTION
There is some bug where when my bot tries to send a very very long message (somebody played with my echo), the telegram api throws an error (message too long) but still sends the message to the group. The bot will try to resend the message (because the offset is unchanged) in an endless loop. I fixed it with changing the offset to one (but there might be better solutions for adjusting the offset). Funny fact: the bot does not spam the message that was too long, but the last message sent by the bot. (eg : bot is spamming the broken message, someone sends /echo abc, the bot start sending abc in an endless loop (and stops sending the broken message))
heres the error message (that is being constantly thrown) :
Error: 400: Bad Request: message is too long
      at buildFetchConfig.then.then.then.then (bot/node_modules/telegraf/core/network/client.js:130:15)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:160:7)

Failed to process updates. { Error: 400: Bad Request: message is too long
    at buildFetchConfig.then.then.then.then (bot/node_modules/telegraf/core/network/client.js:130:15)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:160:7)
  code: 400,
  response: 
   { ok: false,
     error_code: 400,
     description: 'Bad Request: message is too long' },
  description: 'Bad Request: message is too long',
  parameters: {},
  on: 
   { method: 'sendMessage',
     payload: 
      { chat_id: censored,
        text: 'very long text that i removed for clarity`',
        parse_mode: 'Markdown' } } }