### PR TITLE
Add optional messageId param to TelegrafContext::deleteMessage

### DIFF
--- a/core/context.js
+++ b/core/context.js
@@ -461,7 +461,11 @@ class TelegrafContext {
     return this.reply(html, Object.assign({ 'parse_mode': 'HTML' }, extra))
   }
 
-  deleteMessage () {
+  deleteMessage (messageId) {
+    if (messageId !== undefined) {
+      return this.telegram.deleteMessage(this.chat.id, messageId)
+    }
+
     const message = this.message ||
       this.editedMessage ||
       this.channelPost ||


### PR DESCRIPTION
This change makes `ctx.deleteMessage` consistent with other context shortcuts, like `getChatMember`, `kickChatMember`, `promoteChatMember`, `reply`, which are just "scoped" to the current chat.

It just feels so right, to a point in which I tried to use it in my code and [inserted a bug](https://github.com/thedevs-network/the-guard-bot/issues/55) as a result, and I'm sure I'll do it again, hence the PR.