### PR TITLE
Fix TypeScript compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
   - 8
 script:
   - npm run lint
+  - npm run typecheck
   - npm test

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "lint": "eslint .",
     "test": "ava test",
-    "precommit": "npm run lint && npm test"
+    "precommit": "npm run lint && npm run typecheck && npm test",
+    "typecheck": "tsc"
   },
   "engines": {
     "node": ">=6.2.0"
@@ -27,7 +28,8 @@
     "debug": "^3.0.0",
     "node-fetch": "^2.0.0",
     "sandwich-stream": "^1.0.0",
-    "telegram-typings": "^3.6.0"
+    "telegram-typings": "^3.6.0",
+    "typescript": "^2.8.3"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "forceConsistentCasingInFileNames": true
   },
   "files": [
-    "index.d.ts",
-    "telegram-types.d.ts"
+    "typings/index.d.ts",
+    "typings/telegram-types.d.ts"
   ]
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -846,4 +846,3 @@ export class Telegraf<C extends ContextMessageUpdate> extends Composer<C> {
 
 
 export default Telegraf
-

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -78,7 +78,7 @@ interface InputFileByPath {
 }
 
 interface InputFileByReadableStream {
-  source: ReadableStream
+  source: NodeJS.ReadableStream
 }
 
 interface InputFileByBuffer {
@@ -103,87 +103,87 @@ export type InputFile =
      * Sends the message silently. Users will receive a notification with no sound.
      */
     disable_notification?: boolean
-  
+
     /**
      * If the message is a reply, ID of the original message
      */
     reply_to_message_id?: number
-  
+
     /**
      * Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
      */
     reply_markup?: TT.InlineKeyboardMarkup | TT.ReplyKeyboardMarkup | TT.ReplyKeyboardRemove | TT.ForceReply
   }
-  
+
   export interface ExtraEditMessage extends ExtraReplyMessage {
     /**
      * Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
      */
     parse_mode?: ParseMode
-  
+
     /**
      * Disables link previews for links in this message
      */
     disable_web_page_preview?: boolean
-  
+
   }
-  
+
   export interface ExtraAudio extends ExtraReplyMessage {
     /**
      * Audio caption, 0-200 characters
      */
     caption?: string
-  
+
     /**
      * Duration of the audio in seconds
      */
     duration?: number
-  
+
     /**
      * Performer
      */
     performer?: string
-  
+
     /**
      * Track name
      */
     title?: string
   }
-  
+
   export interface ExtraDocument extends ExtraReplyMessage {
     /**
      * Document caption (may also be used when resending documents by file_id), 0-200 characters
      */
     caption?: string
   }
-  
+
   export interface ExtraGame extends ExtraReplyMessage {
     // no specified game props
     // https://core.telegram.org/bots/api#sendgame
   }
-  
+
   export interface ExtraInvoice extends ExtraReplyMessage {
     // no specified invoice props
     // https://core.telegram.org/bots/api#sendinvoice
   }
-  
+
   export interface ExtraLocation extends ExtraReplyMessage {
     // no specified location props
     // https://core.telegram.org/bots/api#sendlocation
   }
-  
+
   export interface ExtraPhoto extends ExtraReplyMessage {
     /**
      * Photo caption (may also be used when resending photos by file_id), 0-200 characters
      */
     caption?: string
   }
-  
+
   export interface ExtraSticker extends ExtraReplyMessage {
     // no specified sticker props
     // https://core.telegram.org/bots/api#sendsticker
   }
-  
+
   export interface ExtraVideo extends ExtraReplyMessage {
     // no specified video props
     // https://core.telegram.org/bots/api#sendvideo
@@ -210,31 +210,31 @@ export type InputFile =
   export interface MessageAudio extends TT.Message {
     audio: TT.Audio
   }
-  
+
   export interface MessageDocument extends TT.Message {
     document: TT.Document
   }
-  
+
   export interface MessageGame extends TT.Message {
     game: TT.Game
   }
-  
+
   export interface MessageInvoice extends TT.Message {
     invoice: TT.Invoice
   }
-  
+
   export interface MessageLocation extends TT.Message {
     location: TT.Location
   }
-  
+
   export interface MessagePhoto extends TT.Message {
     photo: TT.PhotoSize[]
   }
-  
+
   export interface MessageSticker extends TT.Message {
     sticker: TT.Sticker
   }
-  
+
   export interface MessageVideo extends TT.Message {
     video: TT.Video
   }
@@ -244,77 +244,77 @@ export type InputFile =
      * Product name, 1-32 characters
      */
     title: string
-  
+
     /**
      * Product description, 1-255 characters
      */
     description: string
-  
+
     /**
      * Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
      */
     payload: string
-  
+
     /**
      * Payments provider token, obtained via Botfather
      */
     provider_token: string
-  
+
     /**
      * Unique deep-linking parameter that can be used to generate this invoice when used as a start parameter
      */
     start_parameter: string
-  
+
     /**
      * Three-letter ISO 4217 currency code, see more on currencies
      */
     currency: string
-  
+
     /**
      * Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
      */
     prices: TT.LabeledPrice[]
-  
+
     /**
      * URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service. People like it better when they see what they are paying for.
      */
     photo_url?: string
-  
+
     /**
      * Photo size
      */
     photo_size?: number
-  
+
     /**
      * Photo width
      */
     photo_width?: number
-  
+
     /**
      * Photo height
      */
     photo_height?: number
-  
+
     /**
      * Pass True, if you require the user's full name to complete the order
      */
     need_name?: true
-  
+
     /**
      * Pass True, if you require the user's phone number to complete the order
      */
     need_phone_number?: true
-  
+
     /**
      * Pass True, if you require the user's email to complete the order
      */
     need_email?: true
-  
+
     /**
      * Pass True, if you require the user's shipping address to complete the order
      */
     need_shipping_address?: true
-  
+
     /**
      * Pass True, if the final price depends on the shipping method
      */
@@ -326,22 +326,22 @@ export type InputFile =
      * The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
      */
     cache_time?: number
-  
+
     /**
      * Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
      */
     is_personal?: boolean
-  
+
     /**
      * Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
      */
     next_offset?: string
-  
+
     /**
      * If passed, clients will display a button with specified text that switches the user to a private chat with the bot and sends the bot a start message with the parameter switch_pm_parameter
      */
     switch_pm_text?: string
-  
+
     /**
      * Deep-linking parameter for the /start message sent to the bot when user presses the switch button. 1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed.
      */


### PR DESCRIPTION
I wanted to work on a TypeScript project with Telegraf, but discovered it was not compiling. Apparently, the `ReadableStream` interface is defined in the `NodeJS` namespace, which thus requires the prefixing.

To prevent any typings mistakes, I have added a `typecheck` command that runs `tsc` and enforce it in the precommit and on Travis. This caught an additional error in the `tsconfig.json` where the `files` were not correctly specified.