### PR TITLE
Patch README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1697,7 +1697,7 @@ const { leave } = Stage
 // Greeter scene
 const greeter = new Scene('greeter')
 greeter.enter((ctx) => ctx.reply('Hi'))
-greeter.leave((ctx) => ctx.reply('Buy'))
+greeter.leave((ctx) => ctx.reply('Bye'))
 greeter.hears(/hi/gi, leave())
 greeter.on('message', (ctx) => ctx.reply('Send `hi`'))
 


### PR DESCRIPTION
fix typo "Buy" -> "Bye"

# Description

This commit fixes a typo in the documentation.
For a session example instead of "Bye" "Buy" was stated, which is obviously incorrect.


## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?

No need for testing.
