### PR TITLE
Add default export to support Typescript import

### DIFF
--- a/telegraf.js
+++ b/telegraf.js
@@ -160,3 +160,12 @@ module.exports = Object.assign(Telegraf, {
   Telegram,
   session
 })
+
+module.exports.default = Object.assign(Telegraf, {
+  Composer,
+  Extra,
+  Markup,
+  Router,
+  Telegram,
+  session
+})


### PR DESCRIPTION
# Description

Add default export to support Typescript import

**Typescript syntax**
```ts
import Telegraf from "telegraf";

const bot = new Telegraf(process.env.BOT_TOKEN)
```

**Error message (Issue)**

```
$ ts-node index.ts

/Users/mac/Github/telegraf-bot/index.ts:3
const bot = new Telegraf(process.env.BOT_TOKEN)
            ^
TypeError: telegraf_1.default is not a constructor
```

## Type of change

Fixes Typescript, without this change you can't use Typescript with Telegraf
