### PR TITLE
Clear updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1012,6 +1012,12 @@ Use this method to send answers to an inline query.
 | results | `object[]` | Results |
 | [extra] | `object` | [Extra parameters](https://core.telegram.org/bots/api#answerinlinequery)|
 
+##### clearUpdates
+
+Use this method to clear the bot's update queue before starting to poll. Requires no parameters. This method WILL fail if the bot is already polling, or if there is a webhook in place
+
+`telegram.clearUpdates() => Promise`
+
 ##### createNewStickerSet
 
 Use this method to create new sticker set owned by a user.

--- a/telegram.js
+++ b/telegram.js
@@ -30,6 +30,14 @@ class Telegram extends ApiClient {
     })
   }
 
+  clearUpdates () {
+    return this.getUpdates(0, 100, -1)
+      .then((updates) => updates.length > 0
+        ? this.getUpdates(0, 100, updates[updates.length - 1].update_id + 1)
+        : []
+      )
+  }
+
   getWebhookInfo () {
     return this.callApi(`getWebhookInfo`)
   }


### PR DESCRIPTION
# Description

Added a method `telegram.clearUpdates` which clears the update queue of the bot. Useful to ignore old messages when starting the bot

Fixes #454 

## Type of change

- [X] Documentation (typos, code examples or any documentation update)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [X] Tests pass
- [X] Linter has no complaints
- [X] Tested on a bot, both before and after starting to poll. Works as expected
- [ ] Tested with webhooks. Expected to work when no webhook is in place, and fail when there is one, but I have not tested

**Test Configuration**:
* Node.js Version: 8.11.3
* Operating System: Kubuntu 18.04

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
