### PR TITLE
Adds the option to reconnect after a 409 error

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -848,8 +848,9 @@ export class Telegraf<C extends ContextMessageUpdate> extends Composer<C> {
    * @param timeout Poll timeout in seconds
    * @param limit Limits the number of updates to be retrieved
    * @param allowedUpdates List the types of updates you want your bot to receive
+   * @param reconnectAfterConflict Prevent bot from stopping after a 409 error (getUpdates request conflict)
    */
-  startPolling(timeout?: number, limit?: number, allowedUpdates?: tt.UpdateType[]): Telegraf<C>
+  startPolling(timeout?: number, limit?: number, allowedUpdates?: tt.UpdateType[], reconnectAfterConflict?: boolean): Telegraf<C>
 
   /**
    * Start listening @ https://host:port/webhookPath for Telegram calls.


### PR DESCRIPTION
# Description

Adds the option to prevent Telegraf from stop working after a 409 error. This error happens when the getUpdates call to API has a conflict with another request.

## Type of change

- [x] Documentation (typos, code examples or any documentation update)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The breaking change exists because of the order of the `startPolling` arguments. I decided to keep the callback at the end to respect the style format but it can be changed easily by the the maintainers if needed.

# How Has This Been Tested?

This is actually a minor change that does not involve a global impact, so no big tests are needed. However, I tested it by creating a basic bot and forcing the 409 error.

Code:
```
const Telegraf = require('./telegraf.js')

const bot = new Telegraf("BOT_TOKEN"})

bot.on("message", ctx => {
  console.log(ctx.message);
})

bot.startPolling(undefined, undefined, undefined, true)
```

URL to force conflict (You have to replace BOT TOKEN by the real token):
https://api.telegram.org/botBOT_TOKEN/getUpdates?offset=0&limit=100&timeout=30


**Test Configuration**:
* Node.js Version: v8.9.1
* Operating System: Windows 10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
