### PR TITLE
Add telegram.sendAnimation typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -518,6 +518,12 @@ export interface Telegram {
   exportChatInviteLink(chatId: number | string): Promise<string>
 
   /**
+   * Use this method to get basic information about the bot
+   * @returns a User object on success.
+   */
+  getMe(): Promise<tt.User>
+
+  /**
    * Use this method to get up to date information about the chat (current name of the user for one-on-one conversations, current username of a user, group or channel, etc.)
    * @param chatId Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
    * @returns a Chat object on success.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -646,6 +646,15 @@ export interface Telegram {
   sendPhoto(chatId: number | string, photo: tt.InputFile, extra?: tt.ExtraPhoto): Promise<tt.MessagePhoto>
 
   /**
+   * Use this method to send .gif animations
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param animation Animation to send. Pass a file_id as String to send a GIF that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a GIF from the Internet, or upload a new GIF using multipart/form-data
+   * @param extra Additional params to send GIF
+   * @returns a Message on success
+   */
+  sendAnimation(chatId: number | string, animation: tt.InputFile, extra?: tt.ExtraAnimation): Promise<tt.MessageAnimation>
+
+  /**
    * Use this method to send .webp stickers
    * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
    * @param sticker Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .webp file from the Internet, or upload a new one using multipart/form-data

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -208,6 +208,13 @@ export type InputFile =
     caption?: string
   }
 
+  export interface ExtraAnimation extends ExtraReplyMessage {
+    /**
+     * Animation caption (may also be used when resending animation by file_id), 0-200 characters
+     */
+    caption?: string
+  }
+
   export interface ExtraSticker extends ExtraReplyMessage {
     // no specified sticker props
     // https://core.telegram.org/bots/api#sendsticker
@@ -225,6 +232,7 @@ export type InputFile =
     document?: TT.Document
     game?: TT.Game
     photo?: TT.PhotoSize[]
+    animation?: TT.Animation
     sticker?: TT.Sticker
     video?: TT.Video
     video_note?: TT.VideoNote
@@ -260,6 +268,10 @@ export type InputFile =
     photo: TT.PhotoSize[]
   }
 
+  export interface MessageAnimation extends TT.Message {
+    animation: TT.Animation
+  }
+  
   export interface MessageSticker extends TT.Message {
     sticker: TT.Sticker
   }


### PR DESCRIPTION
# Description

Add missing typings for `telegram.sendAnimation` and `telegram.getMe`. `telegram.sendAnimation` is very similar to `telegram.sendPhoto` so most changes were copied form there.

Fixes # (issue)

- [x] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested these typings on my own project.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
