### PR TITLE
Replace [extra] param type for telegram.sendMessage

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -580,7 +580,7 @@ export interface Telegram {
    * @param extra SendMessage additional params
    * @returns sent Message if Success
    */
-  sendMessage(chatId: number | string, text: string, extra?: tt.ExtraReplyMessage): Promise<tt.Message>
+  sendMessage(chatId: number | string, text: string, extra?: tt.ExtraEditMessage): Promise<tt.Message>
 
   /**
    * Use this method to send audio files, if you want Telegram clients to display them in the music player.


### PR DESCRIPTION
# Description

Replace typing interface for `sendMessage` extra parameter from `ExtraReplyMessage ` to `ExtraEditMessage`, because this interface support `parse_mode` follow by tg docs (https://core.telegram.org/bots/api#sendmessage)

# Issue

```
TSError: ⨯ Unable to compile TypeScript:
src/telegram/index.ts(53,7): error TS2345: Argument of type '{ parse_mode: string; }' is not assignable to parameter of type 'ExtraReplyMessage'.
  Object literal may only specify known properties, and 'parse_mode' does not exist in type 'ExtraReplyMessage'.
```

# How Has This Been Tested?
```
bot.on("text", ctx => {
  ctx.telegram.sendMessage(
    `${someChanelId}`,
    `Hello *bold*, or _italic_ `,
    {
      parse_mode: "Markdown"
    }
  );
});
```
# Checklist:
* [ ]  My code follows the style guidelines of this project
* [ ]  I have performed a self-review of my own code
* [ ]  My changes generate no new warnings

