### PR TITLE
Implemented immediate abort for long-polling request

### DIFF
--- a/core/network/client.js
+++ b/core/network/client.js
@@ -222,7 +222,7 @@ class ApiClient {
     return this.options.webhookReply
   }
 
-  callApi (method, data = {}) {
+  callApi (method, data = {}, fetchOptions = {}) {
     const { token, options, response, responseEnd } = this
 
     const payload = Object.keys(data)
@@ -247,6 +247,7 @@ class ApiClient {
       .then((config) => {
         const apiUrl = `${options.apiRoot}/bot${token}/${method}`
         config.agent = options.agent
+        Object.assign(config, fetchOptions)
         return fetch(apiUrl, config)
       })
       .then((res) => res.text())

--- a/docs/README.md
+++ b/docs/README.md
@@ -867,7 +867,9 @@ Start listening @ `https://host:port/webhookPath` for Telegram calls.
 
 ##### stop
 
-Stop Webhook and polling
+Stop Webhook or polling
+
+Polling: If [long-polling](https://en.wikipedia.org/wiki/Push_technology#Long_polling) request is active, it will be terminated by [abort signal](https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal) and promise will be returned
 
 `telegraf.stop([callback])`
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "types": "./typings/index.d.ts",
   "dependencies": {
     "@types/node": "^10.1.2",
+    "abort-controller": "^2.0.2",
     "debug": "^4.0.1",
     "node-fetch": "^2.2.0",
     "sandwich-stream": "^2.0.1",

--- a/telegram.js
+++ b/telegram.js
@@ -23,11 +23,11 @@ class Telegram extends ApiClient {
       .then((file) => `${this.options.apiRoot}/file/bot${this.token}/${file.file_path}`)
   }
 
-  getUpdates (timeout, limit, offset, allowedUpdates) {
+  getUpdates (timeout, limit, offset, allowedUpdates, fetchOptions) {
     let url = `getUpdates?offset=${offset}&limit=${limit}&timeout=${timeout}`
     return this.callApi(url, {
       allowed_updates: allowedUpdates
-    })
+    }, fetchOptions)
   }
 
   getWebhookInfo () {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,6 +9,10 @@ import * as tt from './telegram-types.d'
 
 export interface TelegramOptions {
   /**
+   * Telegram server host
+   */
+  apiRoot?: string
+  /**
    * https.Agent instance, allows custom proxy, certificate, keep alive, etc.
    */
   agent?: Agent
@@ -894,6 +898,16 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
   options: TOptions
 
   /**
+   * Launch bot in long-polling or webhook mode.
+   * @param options Launch options
+   */
+  launch({ polling, webhook }: { polling?: {
+    timeout?: number, limit?: number, allowedUpdates?: tt.UpdateType[]
+  }, webhook?: {
+    webhookPath: string, tlsOptions: TlsOptions | null, port: number, host?: string
+  } }): Promise<Telegraf<TContext>>
+
+  /**
    * Start poll updates.
    * @param timeout Poll timeout in seconds
    * @param limit Limits the number of updates to be retrieved
@@ -911,9 +925,9 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
   startWebhook(webhookPath: string, tlsOptions: TlsOptions | null, port: number, host?: string): Telegraf<TContext>
 
   /**
-   * Stop Webhook and polling
+   * Stop Webhook or polling
    */
-  stop(): Telegraf<TContext>
+  stop(): Telegraf<TContext> | Promise<void>
 
   /**
    * Return a callback function suitable for the http[s].createServer() method to handle a request.


### PR DESCRIPTION
# Description

I am using `telegraf` in e2e tests. So on each `beforeAll` I need to create `Telegraf` instance and on each `afterAll` destroy it. And this does not work, because long-polling request does not terminates and hence `Jest` shows me that and also I can not create immediately new instance (probably #462 will be fixed too ).

Fixes #462

## Type of change

- [x] Documentstion (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (`stop()` function update)

# How Has This Been Tested?

I added tests into `test/telegraf.js`. I create simple mock http server, within this server I count `long-polling` requests and resolve/reject according to the test logic.

- [x] should throw duplicate long polling request error
- [x] should immediate terminate long polling requests
- [x] should recover long polling request after immediate terminate

**Test Configuration**:
* `HTTP/TCP` on `127.0.0.1`/`localhost` must be allowed
* Node.js Version: 8
* Operating System: Ubuntu 18.04

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
