### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1825,7 +1825,7 @@ Sends voice.
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | `number/string` | Chat id |
-| voice | `File` | Document |
+| voice | `string` | File id |
 | [extra] | `object` | [Extra parameters](https://core.telegram.org/bots/api#sendvoice)|
 
 ##### stopMessageLiveLocation

--- a/docs/README.md
+++ b/docs/README.md
@@ -1825,7 +1825,7 @@ Sends voice.
 | Param | Type | Description |
 | --- | --- | --- |
 | chatId | `number/string` | Chat id |
-| voice | `string` | File id |
+| voice | `File/string` | File, file id or HTTP URL |
 | [extra] | `object` | [Extra parameters](https://core.telegram.org/bots/api#sendvoice)|
 
 ##### stopMessageLiveLocation


### PR DESCRIPTION
Judging by the documentation, the sendVoice method takes a voice of the File type, when in practice it is only necessary to transmit file_id. I propose to make corrections to the documentation.
