### PR TITLE
fix missing UrlButton compatibility from Markup.inlineKeyboard typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1038,7 +1038,7 @@ export class Markup {
 
   static keyboard(buttons: (Buttons | string)[], options?: object): tt.InlineKeyboardMarkup;
 
-  static inlineKeyboard(buttons: CallbackButton[] | CallbackButton[][], options?: object): tt.InlineKeyboardMarkup;
+  static inlineKeyboard(buttons: CallbackButton[] | CallbackButton[][] | UrlButton[] | UrlButton[][], options?: object): tt.InlineKeyboardMarkup;
 
   static resize(value?: boolean): Markup;
 


### PR DESCRIPTION
# Description

`UrlButton[]` and `UrlButton[][]` were missing from `Markup.inlineKeyboard` typings as accepted argument types.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

**Test Configuration**:
* Node.js Version: 9.2.1
* Operating System: Mac OS 10.14.2 Mojave

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
