### PR TITLE
Fix not updated session variable

### DIFF
--- a/session.js
+++ b/session.js
@@ -23,11 +23,10 @@ module.exports = function (opts) {
           get: function () { return session },
           set: function (newValue) { session = Object.assign({}, newValue) }
         })
-        const newState = {
+        return next(ctx).then(() => options.store.set(key, {
           session,
           expires: ttlMs ? now + ttlMs : null
-        }
-        return next(ctx).then(() => options.store.set(key, newState))
+        }))
       })
   }
 }


### PR DESCRIPTION
# Description

`newState` holds a *copy* of object, not the reference to current as tests showed. I extracted `newState` and inlined it into `options.store.set(...)` so `session` will be a new session object rather than old and not modified.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried test program which writes to session and then reads from it. It didn't work with current state but it passed with my changes successfully.

Also I ran all tests via `npm run test` and triggered a lint using `npm run lint`. Both of them didn't show any warnings/errors.

**Test Configuration**:
* Node.js Version: v11.1.0
* Operating System: macOS 10.14.3 and Debian 9 Stretch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
