### PR TITLE
fix: update typings for inline keyboard

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1019,7 +1019,7 @@ export class Markup {
 
   oneTime(value?: boolean): Markup;
 
-  inlineKeyboard(buttons: (CallbackButton | UrlButton)[] | (CallbackButton | UrlButton)[][], options: object): tt.InlineKeyboardMarkup;
+  inlineKeyboard(buttons: Buttons[] | Buttons[][], options: object): tt.InlineKeyboardMarkup;
 
   button(text: string, hide: boolean): Button;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1019,7 +1019,7 @@ export class Markup {
 
   oneTime(value?: boolean): Markup;
 
-  inlineKeyboard(buttons: CallbackButton[] | CallbackButton[][] | UrlButton[] | UrlButton[][], options: object): tt.InlineKeyboardMarkup;
+  inlineKeyboard(buttons: (CallbackButton | UrlButton)[] | (CallbackButton | UrlButton)[][], options: object): tt.InlineKeyboardMarkup;
 
   button(text: string, hide: boolean): Button;
 


### PR DESCRIPTION
Now you cant use in same array `callbackButton` and `urlButton` like this:
```ts
inlineKeyboard([
  [urlButton('tg', 'https://t.me')],
  [callbackButton('Foo', 'bar')]
])
```
This will result in error
```
TS2345: Argument of type '(CallbackButton[] | UrlButton[])[]' is not assignable to parameter of type 'CallbackButton[] | CallbackButton[][] | UrlButton[] | UrlButton[][]'.
```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Node.js Version:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
