### PR TITLE
Changing log position in the TS typings.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1118,6 +1118,8 @@ export interface TelegrafConstructor {
    * new Telegraf(token, options)
    */
   new <TContext extends ContextMessageUpdate>(token: string, options?: TelegrafOptions): Telegraf<TContext>;
+
+  log(logFn?: Function): Middleware<ContextMessageUpdate>;
 }
 
 export interface TOptions {


### PR DESCRIPTION
# Description
To better integrate the provided TS typings, an update was due to change the location of the "log" method.

## Type of change
Changing the place of the log method.

Please delete options that are not relevant.

# How Has This Been Tested?
It has not been tested in the telegraf repo -- but I'm using this update typing in my [bot](https://github.com/Fazendaaa/I-m-a-Spoiler-Bot).

# Checklist:
- [x] I have performed a self-review of my own code