### PR TITLE
Fix Typescript types error in Koa middleware (bot.handleUpdate)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -574,7 +574,7 @@ bot.telegram.setWebhook('https://server.tld:8443/secret-path')
 const app = new Koa()
 app.use(koaBody())
 app.use((ctx, next) => ctx.method === 'POST' || ctx.url === '/secret-path'
-  ? bot.handleUpdate(ctx.request.body, ctx.res)
+  ? bot.handleUpdate(ctx.request.body, ctx.response)
   : next()
 )
 app.listen(3000)

--- a/docs/README.md
+++ b/docs/README.md
@@ -574,7 +574,7 @@ bot.telegram.setWebhook('https://server.tld:8443/secret-path')
 const app = new Koa()
 app.use(koaBody())
 app.use((ctx, next) => ctx.method === 'POST' || ctx.url === '/secret-path'
-  ? bot.handleUpdate(ctx.request.body, ctx.response)
+  ? bot.handleUpdate(ctx.request.body, ctx.res)
   : next()
 )
 app.listen(3000)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -948,14 +948,14 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
    * You may also use this callback function to mount your telegraf app in a Koa/Connect/Express app.
    * @param webhookPath Webhook url path (see Telegraf.setWebhook)
    */
-  webhookCallback(webhookPath: string): (req: IncomingMessage, res: ServerResponse) => void
+  webhookCallback(webhookPath: string): (req: IncomingMessage, res: ServerResponse | Response) => void
 
   /**
    * Handle raw Telegram update. In case you use centralized webhook server, queue, etc.
    * @param rawUpdate Telegram update payload
    * @param webhookResponse http.ServerResponse
    */
-  handleUpdate(rawUpdate: tt.Update, webhookResponse?: ServerResponse): Promise<any>
+  handleUpdate(rawUpdate: tt.Update, webhookResponse?: ServerResponse | Response): Promise<any>
 
   catch(logFn?: Function): void;
 }


### PR DESCRIPTION
# Description

Конфликт типов в Typescript v 3.5.1, Koa 2.7.0, Koa-body 4.1.0
<img width="1003" alt="Снимок экрана 2019-06-07 в 15 07 24" src="https://user-images.githubusercontent.com/39828645/59103287-1d57a300-8937-11e9-9c72-cbefe9ed9eda.png">

```
app.use(ctx => bot.handleUpdate(ctx.request.body, ctx.res))
```

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
