### PR TITLE
Typings markup inlineKeyboard

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1065,7 +1065,7 @@ export class Markup {
 
   oneTime(value?: boolean): Markup;
 
-  inlineKeyboard(buttons: Buttons[] | Buttons[][], options: object): tt.InlineKeyboardMarkup;
+  inlineKeyboard(buttons: Buttons[] | Buttons[][], options: object): Markup & tt.InlineKeyboardMarkup;
 
   button(text: string, hide: boolean): Button;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1091,7 +1091,7 @@ export class Markup {
 
   static keyboard(buttons: (Buttons | string)[], options?: object): tt.InlineKeyboardMarkup;
 
-  static inlineKeyboard(buttons: CallbackButton[] | CallbackButton[][] | UrlButton[] | UrlButton[][], options?: object): tt.InlineKeyboardMarkup;
+  static inlineKeyboard(buttons: CallbackButton[] | CallbackButton[][] | UrlButton[] | UrlButton[][], options?: object): Markup & tt.InlineKeyboardMarkup;
 
   static resize(value?: boolean): Markup;
 

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -1,6 +1,7 @@
 // This is a test file for the TypeScript typings.
 // It is not intended to be used by external users.
-import Telegraf from './index';
+import Telegraf, { Markup } from './index';
+
 
 const randomPhoto = 'https://picsum.photos/200/300/?random'
 const sayYoMiddleware = ({ reply }, next) => reply('yo').then(() => next())
@@ -34,3 +35,10 @@ bot.startWebhook('/secret-path', null, 5000)
 
 // Start polling
 bot.startPolling()
+
+
+// Markup
+
+const markup = new Markup
+markup.inlineKeyboard([Markup.button('sample')], {})
+Markup.inlineKeyboard([Markup.callbackButton('sampleText', 'sampleData')], {})


### PR DESCRIPTION
# Description

Markup.InlineKeyboard method returns the Markup object and we can chain multiple Markup method calls.
I fixed types in method declaration so we could do things like `Markup.inlineKeyboard(...).extra()`

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Code from examples and a few lines in test.ts.

**Test Configuration**:
* Node.js Version:
* Operating System:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
