### PR TITLE
TelegramOptions apiRoot typing fix.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -17,6 +17,11 @@ export interface TelegramOptions {
    * Reply via webhook
    */
   webhookReply?: boolean
+
+  /**
+   * Path to API. default: https://api.telegram.org
+   */
+  apiRoot?: string
 }
 
 export interface Context {
@@ -571,7 +576,7 @@ export interface Telegram {
    * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
    * @param user_id Unique identifier of the target user
    * @param extra Additional params for restrict chat member
-   * @returns True on success 
+   * @returns True on success
    */
   restrictChatMember(chatId: string | number, userId: number, extra?: {
     until_date?: boolean,


### PR DESCRIPTION
# Description
Added missing typing for apiRoot option in TelegramOptions

Fixes #  
![image](https://user-images.githubusercontent.com/4447247/62721620-4834a500-ba15-11e9-9970-d5b4651715ff.png)


## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
None

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
