### PR TITLE
Fixed setWebhook's maxConnections param description

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1916,7 +1916,7 @@ Specifies an url to receive incoming updates via an outgoing webhook.
 | ---  | --- | --- |
 | url  | `string` | Public url for webhook |
 | [cert] | `File` | SSL public certificate |
-| [maxConnections] | `number` | User id |
+| [maxConnections] | `number` | Maximum allowed number of simultaneous HTTPS connections to the webhook |
 | [allowedUpdates] | `string[]` | List the types of updates you want your bot to receive |
 
 ##### unbanChatMember


### PR DESCRIPTION
# Description

Documentation for setWebhook method shows `User id` for the description of `maxConnections` parameter. (probably leftover from copy-pasting the table syntax)

## Type of change
- [x] Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?

N/A

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
