### PR TITLE
Update Webhooks example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -495,12 +495,14 @@ const tlsOptions = {
   key: fs.readFileSync('server-key.pem'),
   cert: fs.readFileSync('server-cert.pem'),
   ca: [
-    // This is necessary only if the client uses the self-signed certificate.
+    // This is necessary only if the client uses a self-signed certificate.
     fs.readFileSync('client-cert.pem')
   ]
 }
 
 // Set telegram webhook
+// The second argument is necessary only if the client uses a self-signed 
+// certificate. Including it for a verified certificate may cause things to break.
 bot.telegram.setWebhook('https://server.tld:8443/secret-path', {
   source: 'server-cert.pem'
 })


### PR DESCRIPTION
Update the webhooks example to indicate that inclusion of a public cert when setting the webhook for trusted certificates may cause things to break. Specifically, Telegram may return an error along the lines of "SSL verification error".

# Description

This took me **days** to figure out. I've learned far more about ports and SSL than I'll ever need to know. At the end of the day it was the simple inclusion of a certificate. [The webhook guide](https://core.telegram.org/bots/webhooks#how-do-i-set-a-webhook-for-either-type) supports this, as well as [the docs](https://core.telegram.org/bots/api#setwebhook) (vaguely).

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- N/A

**Test Configuration**:
N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
