### PR TITLE
Fix answering to webhook query in express app with compression middleware

### DIFF
--- a/core/network/client.js
+++ b/core/network/client.js
@@ -183,9 +183,15 @@ function answerToWebhook (response, payload = {}) {
     if (!response.headersSent) {
       response.setHeader('content-type', 'application/json')
     }
-    return new Promise((resolve) =>
-      response.end(JSON.stringify(payload), 'utf-8', () => resolve(WEBHOOK_REPLY_STUB))
-    )
+    return new Promise((resolve) => {
+      const params = [JSON.stringify(payload), 'utf-8', () => resolve(WEBHOOK_REPLY_STUB)]
+      if (response.end.length === 2) {
+        response.end(...params.slice(0, 2))
+        params[2]()
+      } else {
+        response.end(...params)
+      }
+    })
   }
 
   return buildFormDataConfig(payload)


### PR DESCRIPTION
When express with the [compression](https://www.npmjs.com/package/compression) middleware is used, `response.end` gets overridden by [this](https://github.com/expressjs/compression/blob/master/index.js#L92) signature, that doesn't have a callback parameter. Therefore [this promise](https://github.com/telegraf/telegraf/blob/develop/core/network/client.js#L186) never resolves and execution stops.

I found an [old issue](https://github.com/expressjs/compression/issues/46) in the compression Github repo concerning adding the callback parameter, but it ended in a [PR](https://github.com/expressjs/compression/pull/101) from 2017 that is not going to be merged soon.

What is more, there is [shrink-ray](https://www.npmjs.com/package/shrink-ray) that also can be used behaves the same as `compression`.

That PR that simply checks the number of arguments for the `response.end` function and resolve the promise right after `end` if callback is not available.

**May fix** #610, should be tested
**Looks like it fixes** #672, issue creator should test his case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Express project with webhook handling using express and not the default `.startWebhook()` method. Testing was done with the telegraf code changed directly in the node_modules.
- [x] with `compression` middleware enabled
- [x] with `compression` middleware disabled

**Test Configuration**:
* Node.js Version: 10.13.0
* Operating System: MacOS 10.14.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation _(I don't think should make any)_
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works _(Unfortunately I have no idea how to test this. However, if you look at the changes, there is pretty toggle)_
- [x] New and existing unit tests pass locally with my changes
