### PR TITLE
Add parse_mode to ExtraPhoto (fixes #761)

### DIFF
--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -253,6 +253,11 @@ export interface ExtraPhoto extends ExtraReplyMessage {
    * Photo caption (may also be used when resending photos by file_id), 0-200 characters
    */
   caption?: string
+
+  /**
+   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+   */
+  parse_mode?: ParseMode
 }
 
 export interface ExtraMediaGroup extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -250,7 +250,7 @@ export interface ExtraLocation extends ExtraReplyMessage {
 
 export interface ExtraPhoto extends ExtraReplyMessage {
   /**
-   * Photo caption (may also be used when resending photos by file_id), 0-200 characters
+   * Photo caption (may also be used when resending photos by file_id), 0-1024 characters
    */
   caption?: string
 

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -25,7 +25,7 @@ bot.command('foo', reply('http://coub.com/view/9cjmt'))
 
 bot.action('bar', reply('i was here'))
 
-bot.telegram.sendMessage(process.env.BOT_CLIENT_ID,"It's work")
+bot.telegram.sendMessage(process.env.BOT_CLIENT_ID,"It works")
 
 // Start https webhook
 bot.startWebhook('/secret-path', {}, 8443)

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -42,3 +42,7 @@ bot.startPolling()
 const markup = new Markup
 markup.inlineKeyboard([Markup.button('sample')], {})
 Markup.inlineKeyboard([Markup.callbackButton('sampleText', 'sampleData')], {})
+
+
+// #761
+bot.telegram.sendPhoto(1, randomPhoto, { caption: '*Caption*', parse_mode: 'Markdown' });


### PR DESCRIPTION
# Description

As per the [official documentation](https://core.telegram.org/bots/api#sendphoto), Telegram accepts `parse_mode` settings for `sendPhoto()`. This PR adds `parse_mode` to TypeScript definition of `ExtraPhoto` interface

Fixes #761

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a test code to `typings/test.ts`.

**Test Configuration**:
* Node.js Version: v12.10.0
* Operating System: Ubuntu 16.04

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
