### PR TITLE
Fix incorrect TypeScript definitions for Telegraf.launch()

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -870,7 +870,7 @@ Start poll updates.
 | --- | --- | --- | --- |
 | [timeout] | `number` | 30 | Poll timeout in seconds |
 | [limit] | `number` | 100 | Limits the number of updates to be retrieved |
-| [allowedUpdates] | `string[]` | null | List the types of updates you want your bot to receive |
+| [allowedUpdates] | `string[]/string/null` | null | List the types of updates you want your bot to receive |
 | [stopCallback] | `function` | null | Polling stop callback |
 
 ##### startWebhook

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1105,7 +1105,7 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
    * @param timeout Poll timeout in seconds
    * @param limit Limits the number of updates to be retrieved
    * @param allowedUpdates List the types of updates you want your bot to receive
-   * @param sropCallback Polling stop callback
+   * @param stopCallback Polling stop callback
    */
   startPolling(timeout?: number, limit?: number, allowedUpdates?: tt.UpdateType[] | tt.UpdateType | null, stopCallback?: () => void | null): Telegraf<TContext>
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1008,6 +1008,60 @@ export interface ComposerConstructor {
 
 export const Telegraf: TelegrafConstructor;
 
+export interface LaunchPollingOptions {
+  /**
+   * Poll timeout in seconds
+   */
+  timeout?: number
+
+  /**
+   * Limits the number of updates to be retrieved
+   */
+  limit?: number
+
+  /**
+   * List the types of updates you want your bot to receive
+   */
+  allowedUpdates?: tt.UpdateType[] | tt.UpdateType | null
+
+  /**
+   * Polling stop callback
+   */
+  stopCallback?: () => void | null
+}
+
+export interface LaunchWebhookOptions {
+  /**
+   * Public domain for webhook. If domain is not specified, hookPath should contain a domain name as well (not only path component).
+   */
+  domain?: string
+
+  /**
+   * Webhook url path; will be automatically generated if not specified
+   */
+  hookPath?: string
+
+  /**
+   * The port to listen on for Telegram calls. If port is omitted or is 0, the operating system will assign an arbitrary unused port.
+   */
+  port?: number
+
+  /**
+   * The host to listen on for Telegram calls. If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.
+   */
+  host?: string
+
+  /**
+   * TLS server options. Pass null (or omit) to use http.
+   */
+  tlsOptions?: TlsOptions | null
+
+  /**
+   * A callback function suitable for the http[s].createServer() method to handle a request.
+   */
+  cb?: (req: IncomingMessage, res: ServerResponse) => void
+}
+
 export interface Telegraf<TContext extends ContextMessageUpdate> extends Composer<TContext> {
   /**
    * Use this property to get/set bot token
@@ -1041,8 +1095,8 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
    */
   launch(
     options?: {
-      polling?: { timeout?: number, limit?: number, allowedUpdates?: tt.UpdateType[] },
-      webhook?: { hookPath: string, tlsOptions: TlsOptions | null, port: number, host?: string }
+      polling?: LaunchPollingOptions,
+      webhook?: LaunchWebhookOptions
     }
   ): Promise<void>
 
@@ -1051,8 +1105,9 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
    * @param timeout Poll timeout in seconds
    * @param limit Limits the number of updates to be retrieved
    * @param allowedUpdates List the types of updates you want your bot to receive
+   * @param sropCallback Polling stop callback
    */
-  startPolling(timeout?: number, limit?: number, allowedUpdates?: tt.UpdateType[]): Telegraf<TContext>
+  startPolling(timeout?: number, limit?: number, allowedUpdates?: tt.UpdateType[] | tt.UpdateType | null, stopCallback?: () => void | null): Telegraf<TContext>
 
   /**
    * Start listening @ https://host:port/hookPath for Telegram calls.
@@ -1060,8 +1115,9 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
    * @param tlsOptions TLS server options. Pass null to use http
    * @param port Port number
    * @param host Hostname
+   * @param cb A callback function suitable for the http[s].createServer() method to handle a request.
    */
-  startWebhook(hookPath: string, tlsOptions: TlsOptions | null, port: number, host?: string): Telegraf<TContext>
+  startWebhook(hookPath: string, tlsOptions?: TlsOptions | null, port?: number, host?: string, cb?: (req: IncomingMessage, res: ServerResponse) => void): Telegraf<TContext>
 
   /**
    * Stop Webhook and polling

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -36,6 +36,29 @@ bot.startWebhook('/secret-path', null, 5000)
 // Start polling
 bot.startPolling()
 
+// Launch - webhook
+bot.launch({ webhook: {} }) // Technically, all webhook parameters are optional, but in this case launch throws an exception
+bot.launch({
+  webhook: {
+    domain: 'https://---.localtunnel.me',
+    port: 3000,
+    hookPath: '/telegraf/mybot',
+    tlsOptions: null,
+    host: '127.0.0.1',
+    cb: (): void => {}
+  }
+})
+
+// Launch - polling
+bot.launch({ polling: {} })
+bot.launch({
+  polling: {
+    timeout: 30,
+    limit: 100,
+    allowedUpdates: null,
+    stopCallback: (): void => {}
+  }
+})
 
 // Markup
 


### PR DESCRIPTION
# Description

TypeScript definitions for `Telegraf.launch()` were incorrect: launch() accepts more options than advertised.

Fixes #762

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added tests to `typings/tests.ts`

**Test Configuration**:
* Node.js Version: v12.10.0
* Operating System: Ubuntu 16.04

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
