### PR TITLE
Update TypeScript definitions for ExtraXXX interfaces

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -187,7 +187,7 @@ export interface ContextMessageUpdate extends Context {
    * @param extra Additional params to send message
    * @returns a Message on success
    */
-  replyWithHTML(html: string, extra?: tt.ExtraEditMessage): Promise<tt.Message>
+  replyWithHTML(html: string, extra?: tt.ExtraReplyMessage): Promise<tt.Message>
 
   /**
    * Use this method to send invoices
@@ -212,7 +212,7 @@ export interface ContextMessageUpdate extends Context {
    * @param extra Additional params to send message
    * @returns a Message on success
    */
-  replyWithMarkdown(markdown: string, extra?: tt.ExtraEditMessage): Promise<tt.Message>
+  replyWithMarkdown(markdown: string, extra?: tt.ExtraReplyMessage): Promise<tt.Message>
 
   /**
    * Use this method to send photos

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -322,6 +322,16 @@ export interface ExtraPhoto extends ExtraReplyMessage {
 export interface ExtraMediaGroup extends ExtraReplyMessage {
   // no specified location props
   // https://core.telegram.org/bots/api#sendmediagroup
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendmediagroup
+   */
+  disable_web_page_preview?: never
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendmediagroup
+   */
+  parse_mode?: never
 }
 
 export interface ExtraAnimation extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -280,6 +280,11 @@ export interface ExtraInvoice extends ExtraReplyMessage {
   // https://core.telegram.org/bots/api#sendinvoice
 
   /**
+   * Inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
+   */
+  reply_markup?: TT.InlineKeyboardMarkup
+
+  /**
    * Does not exist, see https://core.telegram.org/bots/api#sendinvoice
    */
   disable_web_page_preview?: never

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -248,9 +248,19 @@ export interface ExtraAudio extends ExtraReplyMessage {
 
 export interface ExtraDocument extends ExtraReplyMessage {
   /**
-   * Document caption (may also be used when resending documents by file_id), 0-200 characters
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
+   * The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 320.
+   * Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file,
+   * so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>.
+   */
+  thumb?: InputFile
+
+  /**
+   * Document caption (may also be used when resending documents by file_id), 0-1024 characters
    */
   caption?: string
+
+  // FIXME: inherits disable_web_page_preview from ExtraReplyMessage, but this property does not exist
 }
 
 export interface ExtraGame extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -216,7 +216,7 @@ export interface ExtraEditMessage extends ExtraReplyMessage {
 
 export interface ExtraAudio extends ExtraReplyMessage {
   /**
-   * Audio caption, 0-200 characters
+   * Audio caption, 0-1024 characters
    */
   caption?: string
 
@@ -234,6 +234,16 @@ export interface ExtraAudio extends ExtraReplyMessage {
    * Track name
    */
   title?: string
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
+   * The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 320.
+   * Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file,
+   * so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>.
+   */
+  thumb?: InputFile
+
+  // FIXME: inherits disable_web_page_preview from ExtraReplyMessage, but this property does not exist
 }
 
 export interface ExtraDocument extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -318,9 +318,9 @@ export interface ExtraPhoto extends ExtraReplyMessage {
   caption?: string
 
   /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+   * Does not exist, see https://core.telegram.org/bots/api#sendphoto
    */
-  parse_mode?: ParseMode
+  disable_web_page_preview?: never
 }
 
 export interface ExtraMediaGroup extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -234,7 +234,10 @@ export interface ExtraAudio extends ExtraReplyMessage {
    */
   thumb?: InputFile
 
-  // FIXME: inherits disable_web_page_preview from ExtraReplyMessage, but this property does not exist
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendaudio
+   */
+  disable_web_page_preview?: never
 }
 
 export interface ExtraDocument extends ExtraReplyMessage {
@@ -251,21 +254,40 @@ export interface ExtraDocument extends ExtraReplyMessage {
    */
   caption?: string
 
-  // FIXME: inherits disable_web_page_preview from ExtraReplyMessage, but this property does not exist
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#senddocument
+   */
+  disable_web_page_preview?: never
 }
 
 export interface ExtraGame extends ExtraReplyMessage {
   // no specified game props
   // https://core.telegram.org/bots/api#sendgame
 
-  // FIXME: does not have these inherited properties: parse_mode, disable_web_page_preview
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#senddocument
+   */
+  disable_web_page_preview?: never
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#senddocument
+   */
+  parse_mode?: never
 }
 
 export interface ExtraInvoice extends ExtraReplyMessage {
   // no specified invoice props
   // https://core.telegram.org/bots/api#sendinvoice
 
-  // FIXME: does not have these inherited proeprties: parse_mode, disable_web_page_preview
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendinvoice
+   */
+  disable_web_page_preview?: never
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendinvoice
+   */
+  parse_mode?: never
 }
 
 export interface ExtraLocation extends ExtraReplyMessage {
@@ -274,7 +296,15 @@ export interface ExtraLocation extends ExtraReplyMessage {
    */
   live_period?: number
 
-  // FIXME: does not have these inherited proeprties: parse_mode, disable_web_page_preview
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendlocation
+   */
+  disable_web_page_preview?: never
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendlocation
+   */
+  parse_mode?: never
 }
 
 export interface ExtraPhoto extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -202,16 +202,7 @@ export interface ExtraReplyMessage {
 }
 
 export interface ExtraEditMessage extends ExtraReplyMessage {
-  /**
-   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-   */
-  parse_mode?: ParseMode
-
-  /**
-   * Disables link previews for links in this message
-   */
-  disable_web_page_preview?: boolean
-
+  // no specified properties
 }
 
 export interface ExtraAudio extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -264,11 +264,17 @@ export interface ExtraGame extends ExtraReplyMessage {
 export interface ExtraInvoice extends ExtraReplyMessage {
   // no specified invoice props
   // https://core.telegram.org/bots/api#sendinvoice
+
+  // FIXME: does not have these inherited proeprties: parse_mode, disable_web_page_preview
 }
 
 export interface ExtraLocation extends ExtraReplyMessage {
-  // no specified location props
-  // https://core.telegram.org/bots/api#sendlocation
+  /**
+   * Period in seconds for which the location will be updated (should be between 60 and 86400)
+   */
+  live_period?: number
+
+  // FIXME: does not have these inherited proeprties: parse_mode, disable_web_page_preview
 }
 
 export interface ExtraPhoto extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -409,6 +409,11 @@ export interface ExtraVoice extends ExtraReplyMessage {
    * Duration of the voice message in seconds
    */
   duration?: number
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendvoice
+   */
+  disable_web_page_preview?: never
 }
 
 export interface IncomingMessage extends TT.Message {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -176,6 +176,16 @@ export type InputFile =
 export interface ExtraReplyMessage {
 
   /**
+   * Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+   */
+  parse_mode?: ParseMode
+
+  /**
+   * Disables link previews for links in this message
+   */
+  disable_web_page_preview?: boolean
+
+  /**
    * Sends the message silently. Users will receive a notification with no sound.
    */
   disable_notification?: boolean

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -360,8 +360,43 @@ export interface ExtraSticker extends ExtraReplyMessage {
 }
 
 export interface ExtraVideo extends ExtraReplyMessage {
-  // no specified video props
-  // https://core.telegram.org/bots/api#sendvideo
+  /**
+   * Duration of sent video in seconds
+   */
+  duration?: number
+
+  /**
+   * Video width
+   */
+  width?: number
+
+  /**
+   * Video height
+   */
+  height?: number
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
+   * The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 320.
+   * Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file,
+   * so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>.
+   */
+  thumb?: InputFile
+
+  /**
+   * Video caption (may also be used when resending videos by file_id), 0-1024 characters
+   */
+  caption?: string
+
+  /**
+   * Pass True, if the uploaded video is suitable for streaming
+   */
+  supports_streaming?: boolean
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendvideo
+   */
+  disable_web_page_preview?: never
 }
 
 export interface ExtraVoice extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -348,8 +348,15 @@ export interface ExtraAnimation extends ExtraReplyMessage {
 }
 
 export interface ExtraSticker extends ExtraReplyMessage {
-  // no specified sticker props
-  // https://core.telegram.org/bots/api#sendsticker
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendsticker
+   */
+  disable_web_page_preview?: never
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendsticker
+   */
+  parse_mode?: never
 }
 
 export interface ExtraVideo extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -261,24 +261,23 @@ export interface ExtraDocument extends ExtraReplyMessage {
 }
 
 export interface ExtraGame extends ExtraReplyMessage {
-  // no specified game props
-  // https://core.telegram.org/bots/api#sendgame
+  /**
+   * Inline keyboard. If empty, one ‘Play game_title’ button will be shown. If not empty, the first button must launch the game.
+   */
+  reply_markup?: TT.InlineKeyboardMarkup
 
   /**
-   * Does not exist, see https://core.telegram.org/bots/api#senddocument
+   * Does not exist, see https://core.telegram.org/bots/api#sendgame
    */
   disable_web_page_preview?: never
 
   /**
-   * Does not exist, see https://core.telegram.org/bots/api#senddocument
+   * Does not exist, see https://core.telegram.org/bots/api#sendgame
    */
   parse_mode?: never
 }
 
 export interface ExtraInvoice extends ExtraReplyMessage {
-  // no specified invoice props
-  // https://core.telegram.org/bots/api#sendinvoice
-
   /**
    * Inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
    */
@@ -325,9 +324,6 @@ export interface ExtraPhoto extends ExtraReplyMessage {
 }
 
 export interface ExtraMediaGroup extends ExtraReplyMessage {
-  // no specified location props
-  // https://core.telegram.org/bots/api#sendmediagroup
-
   /**
    * Does not exist, see https://core.telegram.org/bots/api#sendmediagroup
    */
@@ -337,6 +333,11 @@ export interface ExtraMediaGroup extends ExtraReplyMessage {
    * Does not exist, see https://core.telegram.org/bots/api#sendmediagroup
    */
   parse_mode?: never
+
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#sendmediagroup
+   */
+  reply_markup?: never
 }
 
 export interface ExtraAnimation extends ExtraReplyMessage {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -266,6 +266,8 @@ export interface ExtraDocument extends ExtraReplyMessage {
 export interface ExtraGame extends ExtraReplyMessage {
   // no specified game props
   // https://core.telegram.org/bots/api#sendgame
+
+  // FIXME: does not have these inherited properties: parse_mode, disable_web_page_preview
 }
 
 export interface ExtraInvoice extends ExtraReplyMessage {

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -67,6 +67,15 @@ bot.hears('something', (ctx) => {
         parse_mode: "Markdown",
         disable_web_page_preview: true
     })
+
+    // tt.ExtraAudio
+    ctx.replyWithAudio('somefile', {
+        caption: '',
+        duration: 0,
+        performer: '',
+        title: '',
+        thumb: ''
+    })
 })
 
 // Markup

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -1,6 +1,6 @@
 // This is a test file for the TypeScript typings.
 // It is not intended to be used by external users.
-import Telegraf, { Markup, Middleware, ContextMessageUpdate } from './index';
+import Telegraf, { Markup, Middleware, ContextMessageUpdate, Extra } from './index';
 
 const randomPhoto = 'https://picsum.photos/200/300/?random'
 const sayYoMiddleware: Middleware<ContextMessageUpdate> = ({ reply }, next) => reply('yo').then(() => next && next())
@@ -64,7 +64,10 @@ bot.hears('something', (ctx) => {
     // tt.ExtraReplyMessage
     ctx.reply('Response', {
         parse_mode: "Markdown",
-        disable_web_page_preview: true
+        disable_web_page_preview: true,
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.keyboard([])
     })
 
     // tt.ExtraAudio
@@ -89,9 +92,38 @@ bot.hears('something', (ctx) => {
         reply_markup: Markup.inlineKeyboard([])
     })
 
+    // tt.ExtraGame
+    ctx.replyWithGame('game', {
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
+    })
+
     // tt.ExtraLocation
     ctx.replyWithLocation(0, 0, {
         live_period: 60,
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
+    })
+
+    // tt.ExtraPhoto
+    ctx.replyWithPhoto('', {
+        caption: '',
+        parse_mode: 'HTML',
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
+    })
+
+    // tt.ExtraMediaGroup
+    ctx.replyWithMediaGroup([], {
+        disable_notification: false,
+        reply_to_message_id: 0
+    })
+
+    // tt.ExtraSticker
+    ctx.replyWithSticker('', {
         disable_notification: true,
         reply_to_message_id: 0,
         reply_markup: Markup.inlineKeyboard([])

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -110,6 +110,16 @@ bot.hears('something', (ctx) => {
         reply_to_message_id: 0,
         reply_markup: Markup.inlineKeyboard([])
     })
+
+    // tt.ExtraVoice
+    ctx.replyWithVoice('', {
+        caption: '',
+        parse_mode: "Markdown",
+        duration: 0,
+        disable_notification: false,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
+    })
 })
 
 // Markup

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -2,7 +2,6 @@
 // It is not intended to be used by external users.
 import Telegraf, { Markup, Middleware, ContextMessageUpdate } from './index';
 
-
 const randomPhoto = 'https://picsum.photos/200/300/?random'
 const sayYoMiddleware: Middleware<ContextMessageUpdate> = ({ reply }, next) => reply('yo').then(() => next && next())
 
@@ -93,6 +92,20 @@ bot.hears('something', (ctx) => {
     // tt.ExtraLocation
     ctx.replyWithLocation(0, 0, {
         live_period: 60,
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
+    })
+
+    // tt.ExtraVideo
+    ctx.replyWithVideo('', {
+        duration: 0,
+        width: 0,
+        height: 0,
+        thumb: '',
+        caption: '',
+        supports_streaming: false,
+        parse_mode: "HTML",
         disable_notification: true,
         reply_to_message_id: 0,
         reply_markup: Markup.inlineKeyboard([])

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -74,7 +74,10 @@ bot.hears('something', (ctx) => {
         duration: 0,
         performer: '',
         title: '',
-        thumb: ''
+        thumb: '',
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
     })
 
     // tt.ExtraDocument

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -60,6 +60,15 @@ bot.launch({
   }
 })
 
+// tt.ExtraXXX
+bot.hears('something', (ctx) => {
+    // tt.ExtraReplyMessage
+    ctx.reply('Response', {
+        parse_mode: "Markdown",
+        disable_web_page_preview: true
+    })
+})
+
 // Markup
 
 const markup = new Markup

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -76,6 +76,16 @@ bot.hears('something', (ctx) => {
         title: '',
         thumb: ''
     })
+
+    // tt.ExtraDocument
+    ctx.replyWithDocument('document', {
+        thumb: '',
+        caption: '',
+        parse_mode: "HTML",
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
+    })
 })
 
 // Markup

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -89,6 +89,14 @@ bot.hears('something', (ctx) => {
         reply_to_message_id: 0,
         reply_markup: Markup.inlineKeyboard([])
     })
+
+    // tt.ExtraLocation
+    ctx.replyWithLocation(0, 0, {
+        live_period: 60,
+        disable_notification: true,
+        reply_to_message_id: 0,
+        reply_markup: Markup.inlineKeyboard([])
+    })
 })
 
 // Markup


### PR DESCRIPTION
# Description

According to the [official documentation](https://core.telegram.org/bots/api#available-methods), Telegram methods support more parameters than the current typings provide.

This PR adds missing properties (and disables non-existing ones) to ExtraXXX interfaces.

So far, this covers only Context.replyWithXXX() methods.

Fixes #769

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added tests to `typings/test.ts`

**Test Configuration**:
* Node.js Version: 12.10.0
* Operating System: Ubuntu 16.04

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
