### PR TITLE
Add missing await keyword in the keyboard-bot example

### DIFF
--- a/docs/examples/keyboard-bot.js
+++ b/docs/examples/keyboard-bot.js
@@ -100,7 +100,7 @@ bot.action('Dr Pepper', (ctx, next) => {
 
 bot.action('plain', async (ctx) => {
   await ctx.answerCbQuery()
-  ctx.editMessageCaption('Caption', Markup.inlineKeyboard([
+  await ctx.editMessageCaption('Caption', Markup.inlineKeyboard([
     Markup.callbackButton('Plain', 'plain'),
     Markup.callbackButton('Italic', 'italic')
   ]))
@@ -108,7 +108,7 @@ bot.action('plain', async (ctx) => {
 
 bot.action('italic', async (ctx) => {
   await ctx.answerCbQuery()
-  ctx.editMessageCaption('_Caption_', Extra.markdown().markup(Markup.inlineKeyboard([
+  await ctx.editMessageCaption('_Caption_', Extra.markdown().markup(Markup.inlineKeyboard([
     Markup.callbackButton('Plain', 'plain'),
     Markup.callbackButton('* Italic *', 'italic')
   ])))


### PR DESCRIPTION
# Description

This change adds the missing await keyword in the `keyboard-bot` example. Without the await keyword here, the bot may unexpectedly run into an uncached error, such as `Error: 400: Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message`.

## Type of change

- [x] Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?

- [x] Manual tested the code with [a bot](https://t.me/telegraf_keyboard_bot) running on Google Cloud Functions ([source code](https://gist.github.com/zetavg/5dab25e3f2a8da230945d3607c657531)).
