### PR TITLE
fix reply_markup was not passed correctly to body

### DIFF
--- a/telegram.js
+++ b/telegram.js
@@ -300,7 +300,7 @@ class Telegram extends ApiClient {
       chat_id: chatId,
       message_id: messageId,
       inline_message_id: inlineMessageId,
-      reply_markup: markup
+      reply_markup: extra.reply_markup ? extra.reply_markup : extra
     })
   }
 
@@ -311,7 +311,7 @@ class Telegram extends ApiClient {
       chat_id: chatId,
       message_id: messageId,
       inline_message_id: inlineMessageId,
-      reply_markup: markup
+      reply_markup: extra.reply_markup ? extra.reply_markup : extra
     })
   }
 
@@ -320,7 +320,7 @@ class Telegram extends ApiClient {
       chat_id: chatId,
       message_id: messageId,
       inline_message_id: inlineMessageId,
-      reply_markup: markup
+      reply_markup: extra.reply_markup ? extra.reply_markup : extra
     })
   }
 

--- a/telegram.js
+++ b/telegram.js
@@ -295,7 +295,7 @@ class Telegram extends ApiClient {
     })
   }
 
-  editMessageReplyMarkup (chatId, messageId, inlineMessageId, markup) {
+  editMessageReplyMarkup (chatId, messageId, inlineMessageId, extra = {}) {
     return this.callApi('editMessageReplyMarkup', {
       chat_id: chatId,
       message_id: messageId,
@@ -304,7 +304,7 @@ class Telegram extends ApiClient {
     })
   }
 
-  editMessageLiveLocation (latitude, longitude, chatId, messageId, inlineMessageId, markup) {
+  editMessageLiveLocation (latitude, longitude, chatId, messageId, inlineMessageId, extra = {}) {
     return this.callApi('editMessageLiveLocation', {
       latitude,
       longitude,
@@ -315,7 +315,7 @@ class Telegram extends ApiClient {
     })
   }
 
-  stopMessageLiveLocation (chatId, messageId, inlineMessageId, markup) {
+  stopMessageLiveLocation (chatId, messageId, inlineMessageId, extra = {}) {
     return this.callApi('stopMessageLiveLocation', {
       chat_id: chatId,
       message_id: messageId,


### PR DESCRIPTION
# Description

When using telegram client (`telegraf/telegram.js`) method editMessageReplyMarkup directly, reply_markup was not being passed to API call body. Instead it passed Extra instance, which telegram rejected with an error:
```
Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message
```

Since the code is a little inconsistent, I ve decided to just copy/paste the fix from `editMessageMedia` method.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It was not tested, but it should work, since currently I use this method this way:
```js
await telegram.editMessageReplyMarkup(
  chat_id,
  message_id,
  null,
  Extra.markup(...).reply_markup
)
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
