### PR TITLE
Added passing ctx object to error handler

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -155,8 +155,8 @@ To perform custom error-handling logic use following snippet:
 
 ```js
 const bot = new Telegraf(process.env.BOT_TOKEN)
-bot.catch((err) => {
-  console.log('Ooops', err)
+bot.catch((err, ctx) => {
+  console.log(`Ooops, ecountered an error for ${ctx.updateType}`, err)
 })
 bot.start((ctx) => ctx.reply(42/0))
 bot.launch()

--- a/telegraf.js
+++ b/telegraf.js
@@ -160,7 +160,7 @@ class Telegraf extends Composer {
     const tg = new Telegram(this.token, this.telegram.options, webhookResponse)
     const ctx = new Context(update, tg, this.options)
     Object.assign(ctx, this.context)
-    return this.middleware()(ctx).catch(this.handleError)
+    return this.middleware()(ctx).catch((err) => this.handleError(err, ctx))
   }
 
   fetchUpdates () {


### PR DESCRIPTION
# Description

I assume it would be useful to have access to ctx object in error handler.
It will help to centralize error handling like any modern framework usually has (express, koa).
Also I have updated related topic in the documentation

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (present in the PR)

# How Has This Been Tested?

My PR is pretty simple for testing. Just add error handler by bot.catch, throw an error and access the second argument of the function (bot.catch((err, ctx) => {console.log(ctx)}))

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
