### PR TITLE
Actualize telegraf.stop docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -919,7 +919,11 @@ Start listening @ `https://host:port/webhookPath` for Telegram calls.
 
 Stop Webhook and polling
 
-`telegraf.stop() => Promise`
+`telegraf.stop([callback]) => Promise`
+
+| Param | Type |
+| ---  | --- |
+| [callback] | function |
 
 ##### webhookCallback
 

--- a/telegraf.js
+++ b/telegraf.js
@@ -134,7 +134,7 @@ class Telegraf extends Composer {
       })
   }
 
-  stop (cb) {
+  stop (cb = noop) {
     return new Promise((resolve) => {
       const done = () => resolve() & cb()
       if (this.webhookServer) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1122,7 +1122,7 @@ export interface Telegraf<TContext extends ContextMessageUpdate> extends Compose
   /**
    * Stop Webhook and polling
    */
-  stop(): Telegraf<TContext>
+  stop(cb?: () => void): Promise<void>
 
   /**
    * Return a callback function suitable for the http[s].createServer() method to handle a request.


### PR DESCRIPTION
# Description

Hey, 

I've found `stop` doc is outdated so there is an update. In addition I've made this function arg is optional, because `stop` returns Promise and could be chained. 

Also I've asked about this `cb` arg in https://github.com/telegraf/telegraf/issues/816 _Please let me know if it isn't necessary and could be deleted._

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
