### PR TITLE
fix forward type

### DIFF
--- a/context.js
+++ b/context.js
@@ -41,11 +41,11 @@ const MessageSubTypes = [
   'connected_website',
   'passport_data',
   'poll',
-  'forward_from'
+  'forward_date'
 ]
 
 const MessageSubTypesMapping = {
-  forward_from: 'forward'
+  forward_date: 'forward'
 }
 
 class TelegrafContext {

--- a/test/composer.js
+++ b/test/composer.js
@@ -105,11 +105,7 @@ test.cb('should route forward', (t) => {
     t.end()
   })
   const message = {
-    forward_from: {
-      id: 43,
-      is_bot: false,
-      username: 'username'
-    },
+    forward_date: 1460829948,
     ...baseMessage
   }
   bot.handleUpdate({ message: message })


### PR DESCRIPTION
# Description

fix forward type

forward_from is inaccurate for forward detection, it may not be on forward from people who have hidden forward capability. forward_date is always there.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

no

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works