### PR TITLE
Fix promoteChatMember docs (cf1e8f9)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1645,7 +1645,7 @@ Use this method to promote or demote a user in a supergroup or a channel.
 | --- | --- | --- |
 | chatId | `number/string` | Chat id |
 | userId | `number` | User id |
-| title | `object` | [Extra parameters](https://core.telegram.org/bots/api#promotechatmember)|
+| [extra] | `object` | [Extra parameters](https://core.telegram.org/bots/api#promotechatmember)|
 
 ##### setChatAdministratorCustomTitle
 


### PR DESCRIPTION
# Description

Fix a typo in the docs, specifically for `promoteChatMember`.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update