### PR TITLE
Move typings to devdependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,15 +35,14 @@
   },
   "types": "./typings/index.d.ts",
   "dependencies": {
-    "@types/node": "^13.1.0",
     "debug": "^4.0.1",
     "minimist": "^1.2.0",
     "module-alias": "^2.2.2",
     "node-fetch": "^2.2.0",
-    "sandwich-stream": "^2.0.1",
-    "telegram-typings": "^3.6.0"
+    "sandwich-stream": "^2.0.1"
   },
   "devDependencies": {
+    "@types/node": "^13.1.0",
     "ava": "^3.0.0",
     "eslint": "^6.2.2",
     "eslint-config-standard": "^14.1.0",
@@ -53,7 +52,8 @@
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
     "husky": "^4.2.0",
-    "typescript": "^3.0.1"
+    "typescript": "^3.0.1",
+    "telegram-typings": "^3.6.0"
   },
   "keywords": [
     "telegraf",


### PR DESCRIPTION
# Description
Moved @types/node and telegram-typings package to devDependencies

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

- [X] Run Ava

**Test Configuration**:
* Node.js Version: v12.14
* Operating System: Win 10

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
