### PR TITLE
Move "telegram-typings" to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "minimist": "^1.2.0",
     "module-alias": "^2.2.2",
     "node-fetch": "^2.2.0",
-    "sandwich-stream": "^2.0.1"
+    "sandwich-stream": "^2.0.1",
+    "telegram-typings": "^3.6.0"
   },
   "devDependencies": {
     "@types/node": "^13.1.0",
@@ -52,8 +53,7 @@
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
     "husky": "^4.2.0",
-    "typescript": "^3.0.1",
-    "telegram-typings": "^3.6.0"
+    "typescript": "^3.0.1"
   },
   "keywords": [
     "telegraf",


### PR DESCRIPTION
# Description

Move "telegram-typings" to back dependencies.

Fixes compilation with TSC

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. ```npm i```
2. ```npm pack```
3. ```npm i ./telegraf-3.36.0.tgz```
4. ```tsc```

**Test Configuration**:
* Node.js Version: 12.14
* Operating System: Win 10

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
