### PR TITLE
Add missing Telegraf config typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,6 +22,16 @@ export interface TelegramOptions {
    * Path to API. default: https://api.telegram.org
    */
   apiRoot?: string
+  
+  /**
+   * Bot username
+   */
+  username?: string
+  
+  /**
+   * Handle `channel_post` updates as messages.
+   */
+  channelMode?: boolean
 }
 
 export interface Context {


### PR DESCRIPTION
Documentation contains info about two fields been passed to the `Telegraf` options, `username` and `channelMode`. But they are missing in the typings. The PR fixes this.

![image](https://user-images.githubusercontent.com/4586392/73749411-641ec680-476c-11ea-8f6f-f637f1b6d813.png)