### PR TITLE
Don't wait for updates to continue fetching updates

### DIFF
--- a/telegraf.js
+++ b/telegraf.js
@@ -186,10 +186,14 @@ class Telegraf extends Composer {
         console.error(`Failed to fetch updates. Waiting: ${wait}s`, err.message)
         return new Promise((resolve) => setTimeout(resolve, wait * 1000, []))
       })
-      .then((updates) => this.polling.started
-        ? this.handleUpdates(updates).then(() => updates)
-        : []
-      )
+      .then((updates) => {
+        if (!this.polling.started) {
+          return []
+        }
+
+        this.handleUpdates(updates)
+        return updates
+      })
       .catch((err) => {
         console.error('Failed to process updates.', err)
         this.polling.started = false


### PR DESCRIPTION
Long running update handlers blocked the fetchUpdates loop

With this change, updates handlers will be executed in the background, while
the fetchUpdates process starts waiting for more information

# Description

The block of code which executes the update handlers was waiting for them to finish to pass the execution to the next promise block, which calls fetchUpdates again, so the block won't try to get new updates.

Fixes #892

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The issue #892 includes a sample scenario to replicate this issue.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
