### PR TITLE
Fix to track launching result and errors.

### DIFF
--- a/telegraf.js
+++ b/telegraf.js
@@ -108,7 +108,10 @@ class Telegraf extends Composer {
           const { timeout, limit, allowedUpdates, stopCallback } = config.polling || {}
           return this.telegram.deleteWebhook()
             .then(() => this.startPolling(timeout, limit, allowedUpdates, stopCallback))
-            .then(() => debug('Bot started with long-polling'))
+            .then(() => {
+              debug('Bot started with long-polling')
+              return { ok: true, error: null, type: 'long-polling' }
+            })
         }
         if (typeof config.webhook.domain !== 'string' && typeof config.webhook.hookPath !== 'string') {
           throw new Error('Webhook domain or webhook path is required')
@@ -126,11 +129,15 @@ class Telegraf extends Composer {
         }
         return this.telegram
           .setWebhook(`https://${domain}${hookPath}`)
-          .then(() => debug(`Bot started with webhook @ https://${domain}`))
+          .then(() => {
+            debug(`Bot started with webhook @ https://${domain}`)
+            return { ok: true, error: null, type: 'webhook' }
+          })
       })
       .catch((err) => {
         console.error('Launch failed')
         console.error(err.stack || err.toString())
+        return { ok: false, error: { message: 'Launch failed', code: err.code ? err.code : null } }
       })
   }
 


### PR DESCRIPTION
# Description
If the launch failed, it means that the cart could not connect to the server.
You need to return the object with an error in order to be able to track this error.

Fixes #900

I made changes to your code and this allowed me to track the error of the launch.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
```js
bot.launch(options = {})
     .then((data) => {
       if (data !== undefined && !data.ok && data.error !== null)
         console.log ('The launch was a error. message: %s, code: %s',  data.error.message, data.error.code);
       if (data !== undefined && data.ok)
         console.log ('The launch was a success.');
     });
```


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
