### PR TITLE
Fix Markup.inlineKeyboard typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1282,7 +1282,7 @@ export class Markup {
 
   static keyboard(buttons: (Buttons | string)[] | (Buttons | string)[][], options?: object): Markup & tt.ReplyKeyboardMarkup;
 
-  static inlineKeyboard(buttons: CallbackButton[] | CallbackButton[][] | UrlButton[] | UrlButton[][], options?: object): Markup & tt.InlineKeyboardMarkup;
+  static inlineKeyboard(buttons: (CallbackButton | UrlButton)[] | (CallbackButton | UrlButton)[][], options?: object): Markup & tt.InlineKeyboardMarkup;
 
   static resize(value?: boolean): Markup;
 

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -159,6 +159,7 @@ bot.hears('something', (ctx) => {
 const markup = new Markup
 markup.inlineKeyboard([Markup.button('sample')], {})
 Markup.inlineKeyboard([Markup.callbackButton('sampleText', 'sampleData')], {})
+Markup.inlineKeyboard([Markup.callbackButton('sampleCallbackButton', 'sampleData'), Markup.urlButton('sampleUrlButton', 'https://github.com')], {})
 
 
 // #761


### PR DESCRIPTION
# Description

Current typings do not allow mixing `CallbackButton` and `UrlButton` objects in arguments for `Markup.inlineKeyboard()`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tsc typings/test.ts`

**Test Configuration**:
* Node.js Version:
* Operating System:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
