### PR TITLE
When entering a scene, while in a scene: push the former onto a stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "telegraf",
-  "version": "3.36.0",
+  "name": "telegraf_acp_fork",
+  "version": "3.36.2",
   "description": "Modern Telegram Bot Framework",
   "license": "MIT",
   "author": "Vitaly Domnikov <oss@vitaly.codes>",

--- a/scenes/context.js
+++ b/scenes/context.js
@@ -40,11 +40,15 @@ class SceneContext {
     return (sceneId && this.scenes.has(sceneId)) ? this.scenes.get(sceneId) : null
   }
 
-  reset () {
+  reset (keepStack = true) {
     const sessionName = this.options.sessionName
-    const stack = this.stack
-    delete this.ctx[sessionName].__scenes
-    this.session.stack = stack
+    if (keepStack) {
+      const stack = this.stack
+      delete this.ctx[sessionName].__scenes
+      this.session.stack = stack
+    } else {
+      delete this.ctx[sessionName].__scenes
+    }
   }
 
   enter (sceneId, initialState, silent, stack = false) {

--- a/test/scenes.js
+++ b/test/scenes.js
@@ -1,20 +1,19 @@
 const test = require('ava')
 const Telegraf = require('../')
-// const { session } = Telegraf
 
 const baseMessage = { chat: { id: 1 }, from: { id: 42, username: 'telegraf' } }
 
 test('should create a scene', async (t) => {
   const scene1 = new Telegraf.BaseScene('one')
-  let plop = false
-  let patate = false
+  let wentThroughEnter = false
+  let wentThroughEnd = false
   scene1.enter((ctx) => {
-    console.warn('plop')
-    plop = true
+    console.warn('wentThroughEnter')
+    wentThroughEnter = true
   })
   scene1.command('end', (ctx) => {
     console.warn('end')
-    patate = true
+    wentThroughEnd = true
   })
   scene1.command('next', (ctx) => {
     ctx.scene.enter('two')
@@ -30,47 +29,11 @@ test('should create a scene', async (t) => {
   bot.command('foo', (ctx) => ctx.scene.enter('one'))
   bot.command('end', (ctx) => console.error('kappa'))
   await bot.handleUpdate({ message: { text: '/foo', entities: [{ type: 'bot_command', offset: 0, length: 4 }], ...baseMessage } })
-  t.true(plop)
+  t.true(wentThroughEnter)
 
   await bot.handleUpdate({ message: { text: '/next', entities: [{ type: 'bot_command', offset: 0, length: 5 }], ...baseMessage } })
 
   await bot.handleUpdate({ message: { text: '/end', entities: [{ type: 'bot_command', offset: 0, length: 4 }], ...baseMessage } })
 
-  t.true(patate)
-  // scene1.command('checkInOne', (ctx) => {
-  //   console.warn("check in one")
-  //   t.is(ctx.scene.session.current, 'one')
-  //   t.end()
-  // })
-
-  // const scene2 = new Telegraf.BaseScene('two')
-  // scene2.on('text', (ctx) => {
-  //   ctx.scene.leave()
-  //   bot.handleUpdate({
-  //     text: '/checkInOne',
-  //     entities: [{ type: 'bot_command', offset: 0, length: 11 }],
-  //     ...baseMessage
-  //   })
-  // })
-  // const scene3 = new Telegraf.BaseScene('three')
-  // const scene4 = new Telegraf.BaseScene('four')
-  // const bot = new Telegraf()
-
-  // stage.register(scene1, scene2, scene3, scene4)
-  // bot.use(stage.middleware())
-  // bot.command('enter', (ctx) => {
-  //   console.warn("enter")
-
-  //   ctx.scene.enter('one')
-  //   t.is(ctx.scene.session.current, 'two')
-  //   bot.handleUpdate({
-  //     text: 'foo',
-  //     ...baseMessage
-  //   })
-  // })
-  // bot.handleUpdate({
-  //   text: '/enter',
-  //   entities: [{ type: 'bot_command', offset: 0, length: 6 }],
-  //   ...baseMessage
-  // })
+  t.true(wentThroughEnd)
 })

--- a/test/scenes.js
+++ b/test/scenes.js
@@ -1,0 +1,76 @@
+const test = require('ava')
+const Telegraf = require('../')
+// const { session } = Telegraf
+
+const baseMessage = { chat: { id: 1 }, from: { id: 42, username: 'telegraf' } }
+
+test('should create a scene', async (t) => {
+  const scene1 = new Telegraf.BaseScene('one')
+  let plop = false
+  let patate = false
+  scene1.enter((ctx) => {
+    console.warn('plop')
+    plop = true
+  })
+  scene1.command('end', (ctx) => {
+    console.warn('end')
+    patate = true
+  })
+  scene1.command('next', (ctx) => {
+    ctx.scene.enter('two')
+  })
+
+  const scene2 = new Telegraf.BaseScene('two').enter((ctx) => ctx.scene.leave())
+
+  const stage = new Telegraf.Stage([scene1, scene2])
+
+  const bot = new Telegraf()
+  bot.use(Telegraf.session())
+  bot.use(stage.middleware())
+  bot.command('foo', (ctx) => ctx.scene.enter('one'))
+  bot.command('end', (ctx) => console.error('kappa'))
+  await bot.handleUpdate({ message: { text: '/foo', entities: [{ type: 'bot_command', offset: 0, length: 4 }], ...baseMessage } })
+  t.true(plop)
+
+  await bot.handleUpdate({ message: { text: '/next', entities: [{ type: 'bot_command', offset: 0, length: 5 }], ...baseMessage } })
+
+  await bot.handleUpdate({ message: { text: '/end', entities: [{ type: 'bot_command', offset: 0, length: 4 }], ...baseMessage } })
+
+  t.true(patate)
+  // scene1.command('checkInOne', (ctx) => {
+  //   console.warn("check in one")
+  //   t.is(ctx.scene.session.current, 'one')
+  //   t.end()
+  // })
+
+  // const scene2 = new Telegraf.BaseScene('two')
+  // scene2.on('text', (ctx) => {
+  //   ctx.scene.leave()
+  //   bot.handleUpdate({
+  //     text: '/checkInOne',
+  //     entities: [{ type: 'bot_command', offset: 0, length: 11 }],
+  //     ...baseMessage
+  //   })
+  // })
+  // const scene3 = new Telegraf.BaseScene('three')
+  // const scene4 = new Telegraf.BaseScene('four')
+  // const bot = new Telegraf()
+
+  // stage.register(scene1, scene2, scene3, scene4)
+  // bot.use(stage.middleware())
+  // bot.command('enter', (ctx) => {
+  //   console.warn("enter")
+
+  //   ctx.scene.enter('one')
+  //   t.is(ctx.scene.session.current, 'two')
+  //   bot.handleUpdate({
+  //     text: 'foo',
+  //     ...baseMessage
+  //   })
+  // })
+  // bot.handleUpdate({
+  //   text: '/enter',
+  //   entities: [{ type: 'bot_command', offset: 0, length: 6 }],
+  //   ...baseMessage
+  // })
+})

--- a/test/scenes.js
+++ b/test/scenes.js
@@ -3,7 +3,7 @@ const Telegraf = require('../')
 
 const baseMessage = { chat: { id: 1 }, from: { id: 42, username: 'telegraf' } }
 
-test('should create a scene', async (t) => {
+test('should not discard scene after entering a new one', async (t) => {
   const scene1 = new Telegraf.BaseScene('one')
   let wentThroughEnter = false
   let wentThroughEnd = false

--- a/test/scenes.js
+++ b/test/scenes.js
@@ -8,15 +8,13 @@ test('should create a scene', async (t) => {
   let wentThroughEnter = false
   let wentThroughEnd = false
   scene1.enter((ctx) => {
-    console.warn('wentThroughEnter')
     wentThroughEnter = true
   })
   scene1.command('end', (ctx) => {
-    console.warn('end')
     wentThroughEnd = true
   })
   scene1.command('next', (ctx) => {
-    ctx.scene.enter('two')
+    ctx.scene.enter('two', undefined, false, true)
   })
 
   const scene2 = new Telegraf.BaseScene('two').enter((ctx) => ctx.scene.leave())

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -401,11 +401,11 @@ export interface SceneContext<TContext extends SceneContextMessageUpdate> {
 
   reset: () => void;
 
-  enter: (sceneId: string, initialState?: object, silent?: boolean) => Promise<any>;
+  enter: (sceneId: string, initialState?: object, silent?: boolean, stack?: boolean) => Promise<any>;
 
   reenter: () => Promise<any>;
 
-  leave: () => Promise<any>
+  leave: (recover: boolean) => Promise<any>
 }
 
 export interface SceneContextMessageUpdate extends ContextMessageUpdate {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -405,7 +405,7 @@ export interface SceneContext<TContext extends SceneContextMessageUpdate> {
 
   reenter: () => Promise<any>;
 
-  leave: (recover: boolean) => Promise<any>
+  leave: (recover?: boolean) => Promise<any>
 }
 
 export interface SceneContextMessageUpdate extends ContextMessageUpdate {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -399,7 +399,7 @@ export interface SceneContext<TContext extends SceneContextMessageUpdate> {
 
   readonly current: BaseScene<TContext> | null;
 
-  reset: () => void;
+  reset: (keepStack?: boolean) => void;
 
   enter: (sceneId: string, initialState?: object, silent?: boolean, stack?: boolean) => Promise<any>;
 


### PR DESCRIPTION
# Description

I found that it can be interesting not to leave a scene when entering a new one but rather save its state onto a stack for future reuse.

I do not not if that feature is of interest for most people, but thought I'd share.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added unit test file for scenes under `tests/scenes.js`: contains one test that triggers entrance to two scenes and expect the first scene to be active even after having entered and left the second.

**Test Configuration**:
* Node.js Version:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
