### PR TITLE
[Typescript] Fix types for Telegraf.Context and Composer handlers

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -866,7 +866,7 @@ export interface TelegramConstructor {
   new(token: string, options?: TelegramOptions): Telegram;
 }
 
-export interface TelegrafOptions<Context extends ContextMessageUpdate> {
+export interface TelegrafOptions {
   /**
    * Telegram options
    */
@@ -880,7 +880,7 @@ export interface TelegrafOptions<Context extends ContextMessageUpdate> {
   /**
    * Context Type
    */
-  contextType?: Context;
+  contextType?: ContextMessageUpdate;
 
   /**
    * retryAfter
@@ -1421,7 +1421,7 @@ export interface TelegrafConstructor extends ComposerConstructor {
    * @example
    * new Telegraf(token, options)
    */
-  new <TContext extends ContextMessageUpdate>(token: string, options?: TelegrafOptions<TContext>): Telegraf<TContext>;
+  new <TContext extends ContextMessageUpdate>(token: string, options?: TelegrafOptions): Telegraf<TContext>;
 
   Context: ContextMessageUpdate;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -879,20 +879,22 @@ export interface TelegrafOptions {
 
 export const Composer: ComposerConstructor;
 
+export type Handler<T extends ContextMessageUpdate> = Middleware<T> | Composer<T>
+
 export interface Composer<TContext extends ContextMessageUpdate> {
 
   /**
    * Registers a middleware.
    * @param middleware Middleware function
    */
-  use(middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Telegraf<TContext>
+  use(middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Telegraf<TContext>
 
   /**
    * Registers middleware for provided update type.
    * @param updateTypes Update type
    * @param middlewares Middleware functions
    */
-  on(updateTypes: tt.UpdateType | tt.UpdateType[] | tt.MessageSubTypes | tt.MessageSubTypes[], middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Composer<TContext>
+  on(updateTypes: tt.UpdateType | tt.UpdateType[] | tt.MessageSubTypes | tt.MessageSubTypes[], middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Composer<TContext>
 
   /**
    * Return the middleware created by this Composer
@@ -904,52 +906,52 @@ export interface Composer<TContext extends ContextMessageUpdate> {
    * @param triggers Triggers
    * @param middlewares Middleware functions
    */
-  hears(triggers: HearsTriggers, middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Composer<TContext>
+  hears(triggers: HearsTriggers, middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Composer<TContext>
 
   /**
    * Registers middleware for handling callbackQuery data with regular expressions
    * @param triggers Triggers
    * @param middlewares Middleware functions
    */
-  action(triggers: HearsTriggers, middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Composer<TContext>
+  action(triggers: HearsTriggers, middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Composer<TContext>
 
   /**
    * Command handling.
    * @param command Commands
    * @param middlewares Middleware functions
    */
-  command(command: string | string[], middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Composer<TContext>
+  command(command: string | string[], middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Composer<TContext>
 
   /**
    * Registers middleware for handling callback_data actions with game query.
    * @param middlewares Middleware functions
    */
-  gameQuery(middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Composer<TContext>
+  gameQuery(middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Composer<TContext>
 
   /**
    * Registers middleware for handling callback_data actions on start.
    * @param middlewares Middleware functions
    */
-  start(middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Composer<TContext>
+  start(middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Composer<TContext>
 
   /**
    * Registers middleware for handling callback_data actions on help.
    * @param middlewares Middleware functions
    */
-  help(middleware: Middleware<TContext>, ...middlewares: Array<Middleware<TContext>>): Composer<TContext>
+  help(middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Composer<TContext>
 }
 
 export interface ComposerConstructor {
 
   new <TContext extends ContextMessageUpdate>(): Composer<TContext>;
 
-  new <TContext extends ContextMessageUpdate>(...middlewares: Array<Middleware<TContext>>): Composer<TContext>;
+  new <TContext extends ContextMessageUpdate>(...middlewares: Array<Handler<TContext>>): Composer<TContext>;
 
   /**
    * Compose middlewares returning a fully valid middleware comprised of all those which are passed.
    * @param middlewares Array of middlewares functions
    */
-  compose<TContext extends ContextMessageUpdate>(middlewares: Array<Middleware<any>>): Middleware<TContext>
+  compose<TContext extends ContextMessageUpdate>(middlewares: Array<Handler<any>>): Middleware<TContext>
 
   /**
    * Generates middleware for handling provided update types.
@@ -957,7 +959,7 @@ export interface ComposerConstructor {
    * @param middleware Middleware function
    */
   mount<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate>
-    (updateTypes: tt.UpdateType | tt.UpdateType[], ...middleware: Array<Middleware<TContext>>): Middleware<UContext>
+    (updateTypes: tt.UpdateType | tt.UpdateType[], ...middleware: Array<Handler<TContext>>): Middleware<UContext>
 
   /**
    * Generates middleware for handling text messages with regular expressions.
@@ -965,7 +967,7 @@ export interface ComposerConstructor {
    * @param handler Handler
    */
   hears<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate>
-    (triggers: HearsTriggers, ...handler: Array<Middleware<TContext>>): Middleware<UContext>
+    (triggers: HearsTriggers, ...handler: Array<Handler<TContext>>): Middleware<UContext>
 
   /**
    * Generates middleware for handling callbackQuery data with regular expressions.
@@ -973,7 +975,7 @@ export interface ComposerConstructor {
    * @param handler Handler
    */
   action<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate>
-    (triggers: HearsTriggers, ...handler: Array<Middleware<TContext>>): Middleware<UContext>
+    (triggers: HearsTriggers, ...handler: Array<Handler<TContext>>): Middleware<UContext>
 
   /**
    * Generates pass thru middleware.
@@ -991,7 +993,7 @@ export interface ComposerConstructor {
    * @param middleware Middleware function
    */
   optional<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate>
-    (test: boolean | ((ctx: TContext) => boolean), ...middleware: Array<Middleware<TContext>>): Middleware<UContext>
+    (test: boolean | ((ctx: TContext) => boolean), ...middleware: Array<Handler<TContext>>): Middleware<UContext>
 
   /**
    * Generates filter middleware.
@@ -1007,14 +1009,14 @@ export interface ComposerConstructor {
    * @param falseMiddleware false action middleware
    */
   branch<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate, VContext extends ContextMessageUpdate, WContext extends ContextMessageUpdate>
-    (test: boolean | ((ctx: TContext) => boolean), trueMiddleware: Middleware<UContext>, falseMiddleware: Middleware<VContext>): Middleware<WContext>
+    (test: boolean | ((ctx: TContext) => boolean), trueMiddleware: Handler<UContext>, falseMiddleware: Handler<VContext>): Middleware<WContext>
 
   reply<TContext extends ContextMessageUpdate>(text: string, extra?: tt.ExtraReplyMessage): Middleware<TContext>
 
   /**
    * Allows it to console.log each request received.
    */
-  fork<TContext extends ContextMessageUpdate>(middleware: Middleware<TContext>): Function;
+  fork<TContext extends ContextMessageUpdate>(middleware: Handler<TContext>): Function;
 
   log(logFn?: Function): Middleware<ContextMessageUpdate>;
 
@@ -1024,21 +1026,21 @@ export interface ComposerConstructor {
    * @param middleware Middleware function
    */
   chatType<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate>
-    (type: tt.ChatType | tt.ChatType[], ...middleware: Array<Middleware<TContext>>): Middleware<UContext>
+    (type: tt.ChatType | tt.ChatType[], ...middleware: Array<Handler<TContext>>): Middleware<UContext>
 
   /**
    * Generates middleware which passes through when the requested chat type is not a private chat.
    * @param middleware Middleware function
    */
   privateChat<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate>
-    (...middleware: Array<Middleware<TContext>>): Middleware<UContext>
+    (...middleware: Array<Handler<TContext>>): Middleware<UContext>
 
   /**
    * Generates middleware which passes through when the requested chat type is not a group.
    * @param middleware Middleware function
    */
   groupChat<TContext extends ContextMessageUpdate, UContext extends ContextMessageUpdate>
-    (...middleware: Array<Middleware<TContext>>): Middleware<UContext>
+    (...middleware: Array<Handler<TContext>>): Middleware<UContext>
 }
 
 export const Telegraf: TelegrafConstructor;
@@ -1361,9 +1363,9 @@ export class BaseScene<TContext extends SceneContextMessageUpdate> extends Compo
 
   ttl?: number;
 
-  enter: (...fns: Middleware<TContext>[]) => this;
+  enter: (...fns: Handler<TContext>[]) => this;
 
-  leave: (...fns: Middleware<TContext>[]) => this;
+  leave: (...fns: Handler<TContext>[]) => this;
 
   enterMiddleware: () => Middleware<TContext>;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -45,6 +45,7 @@ export interface Context {
 }
 
 export interface ContextMessageUpdate extends Context {
+  new(update: any, telegram: Telegram, options: TOptions): ContextMessageUpdate;
 
   /**
    * Use this method to add a new sticker to a set created by the bot
@@ -336,7 +337,7 @@ export interface ContextMessageUpdate extends Context {
    * @param media New media of message
    * @param markup Markup of inline keyboard
    */
-  editMessageMedia(media: tt.MessageMedia ,extra?: tt.ExtraEditMessage): Promise<tt.Message | boolean>
+  editMessageMedia(media: tt.MessageMedia, extra?: tt.ExtraEditMessage): Promise<tt.Message | boolean>
 
   /**
    * Use this method to delete a message, including service messages, with the following limitations:
@@ -756,7 +757,7 @@ export interface Telegram {
    * @param extra Additional params to send media group
    * @returns On success, an array of the sent Messages is returned
    */
-  sendMediaGroup(chatId: number | string, media: tt.MessageMedia[], extra?: tt.ExtraMediaGroup): Promise<Array<tt.Message>>
+  sendMediaGroup(chatId: number | string, media: tt.MessageMedia[], extra?: tt.ExtraMediaGroup): Promise<Array<tt.Message>>
 
   /**
    * Use this method to send .gif animations
@@ -865,16 +866,31 @@ export interface TelegramConstructor {
   new(token: string, options?: TelegramOptions): Telegram;
 }
 
-export interface TelegrafOptions {
+export interface TelegrafOptions<Context extends ContextMessageUpdate> {
   /**
    * Telegram options
    */
-  telegram?: TelegramOptions
+  telegram?: TelegramOptions;
 
   /**
    * Bot username
    */
-  username?: string
+  username?: string;
+
+  /**
+   * Context Type
+   */
+  contextType?: Context;
+
+  /**
+   * retryAfter
+   */
+  retryAfter?: number;
+
+  /**
+   * handlerTimeout
+   */
+  handlerTimeout?: number;
 }
 
 export const Composer: ComposerConstructor;
@@ -1405,7 +1421,9 @@ export interface TelegrafConstructor extends ComposerConstructor {
    * @example
    * new Telegraf(token, options)
    */
-  new <TContext extends ContextMessageUpdate>(token: string, options?: TelegrafOptions): Telegraf<TContext>;
+  new <TContext extends ContextMessageUpdate>(token: string, options?: TelegrafOptions<TContext>): Telegraf<TContext>;
+
+  Context: ContextMessageUpdate;
 
   log(logFn?: Function): Middleware<ContextMessageUpdate>;
 }

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -1,11 +1,11 @@
 // This is a test file for the TypeScript typings.
 // It is not intended to be used by external users.
-import Telegraf, { Markup, Middleware, ContextMessageUpdate, Extra, Composer } from './index';
+import Telegraf, { Markup, Middleware, ContextMessageUpdate, Extra, Composer, TOptions, Telegram } from './index';
 
 const randomPhoto = 'https://picsum.photos/200/300/?random'
 const sayYoMiddleware: Middleware<ContextMessageUpdate> = ({ reply }, next) => reply('yo').then(() => next && next())
 
-const {reply} =  Telegraf;
+const { reply } = Telegraf;
 
 const bot = new Telegraf(process.env.BOT_TOKEN || '')
 
@@ -44,7 +44,7 @@ bot.launch({
     hookPath: '/telegraf/mybot',
     tlsOptions: null,
     host: '127.0.0.1',
-    cb: (): void => {}
+    cb: (): void => { }
   }
 })
 
@@ -55,103 +55,103 @@ bot.launch({
     timeout: 30,
     limit: 100,
     allowedUpdates: null,
-    stopCallback: (): void => {}
+    stopCallback: (): void => { }
   }
 })
 
 // tt.ExtraXXX
 bot.hears('something', (ctx) => {
-    // tt.ExtraReplyMessage
-    ctx.reply('Response', {
-        parse_mode: "Markdown",
-        disable_web_page_preview: true,
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.keyboard([])
-    })
+  // tt.ExtraReplyMessage
+  ctx.reply('Response', {
+    parse_mode: "Markdown",
+    disable_web_page_preview: true,
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.keyboard([])
+  })
 
-    // tt.ExtraAudio
-    ctx.replyWithAudio('somefile', {
-        caption: '',
-        duration: 0,
-        performer: '',
-        title: '',
-        thumb: '',
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraAudio
+  ctx.replyWithAudio('somefile', {
+    caption: '',
+    duration: 0,
+    performer: '',
+    title: '',
+    thumb: '',
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 
-    // tt.ExtraDocument
-    ctx.replyWithDocument('document', {
-        thumb: '',
-        caption: '',
-        parse_mode: "HTML",
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraDocument
+  ctx.replyWithDocument('document', {
+    thumb: '',
+    caption: '',
+    parse_mode: "HTML",
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 
-    // tt.ExtraGame
-    ctx.replyWithGame('game', {
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraGame
+  ctx.replyWithGame('game', {
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 
-    // tt.ExtraLocation
-    ctx.replyWithLocation(0, 0, {
-        live_period: 60,
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraLocation
+  ctx.replyWithLocation(0, 0, {
+    live_period: 60,
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 
-    // tt.ExtraPhoto
-    ctx.replyWithPhoto('', {
-        caption: '',
-        parse_mode: 'HTML',
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraPhoto
+  ctx.replyWithPhoto('', {
+    caption: '',
+    parse_mode: 'HTML',
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 
-    // tt.ExtraMediaGroup
-    ctx.replyWithMediaGroup([], {
-        disable_notification: false,
-        reply_to_message_id: 0
-    })
+  // tt.ExtraMediaGroup
+  ctx.replyWithMediaGroup([], {
+    disable_notification: false,
+    reply_to_message_id: 0
+  })
 
-    // tt.ExtraSticker
-    ctx.replyWithSticker('', {
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraSticker
+  ctx.replyWithSticker('', {
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 
-    // tt.ExtraVideo
-    ctx.replyWithVideo('', {
-        duration: 0,
-        width: 0,
-        height: 0,
-        thumb: '',
-        caption: '',
-        supports_streaming: false,
-        parse_mode: "HTML",
-        disable_notification: true,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraVideo
+  ctx.replyWithVideo('', {
+    duration: 0,
+    width: 0,
+    height: 0,
+    thumb: '',
+    caption: '',
+    supports_streaming: false,
+    parse_mode: "HTML",
+    disable_notification: true,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 
-    // tt.ExtraVoice
-    ctx.replyWithVoice('', {
-        caption: '',
-        parse_mode: "Markdown",
-        duration: 0,
-        disable_notification: false,
-        reply_to_message_id: 0,
-        reply_markup: Markup.inlineKeyboard([])
-    })
+  // tt.ExtraVoice
+  ctx.replyWithVoice('', {
+    caption: '',
+    parse_mode: "Markdown",
+    duration: 0,
+    disable_notification: false,
+    reply_to_message_id: 0,
+    reply_markup: Markup.inlineKeyboard([])
+  })
 })
 
 // Markup
@@ -193,3 +193,19 @@ composer.start(barMiddleware, otherComposer);
 composer.help(barMiddleware, otherComposer);
 
 bot.use(composer, otherComposer, fooMiddleware);
+
+// Custom Context
+
+class CustomContext extends Telegraf.Context {
+  constructor(update: any, telegram: Telegram, options: TOptions) {
+    console.log('Creating contexy for %j', update);
+    super(update, telegram, options);
+  }
+
+  reply(...args: any) {
+    console.log('reply called with args: %j', args);
+    return super.reply('OK');
+  }
+}
+
+const customContextBot = new Telegraf<CustomContext>('', { contextType: CustomContext });

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -1,6 +1,6 @@
 // This is a test file for the TypeScript typings.
 // It is not intended to be used by external users.
-import Telegraf, { Markup, Middleware, ContextMessageUpdate, Extra } from './index';
+import Telegraf, { Markup, Middleware, ContextMessageUpdate, Extra, Composer } from './index';
 
 const randomPhoto = 'https://picsum.photos/200/300/?random'
 const sayYoMiddleware: Middleware<ContextMessageUpdate> = ({ reply }, next) => reply('yo').then(() => next && next())
@@ -164,3 +164,32 @@ Markup.inlineKeyboard([Markup.callbackButton('sampleCallbackButton', 'sampleData
 
 // #761
 bot.telegram.sendPhoto(1, randomPhoto, { caption: '*Caption*', parse_mode: 'Markdown' });
+
+// type MiddlwareOrCmposer
+
+const composer = new Composer();
+const fooMiddleware: Middleware<ContextMessageUpdate> = (ctx) => ctx.reply('foo');
+const barMiddleware: Middleware<ContextMessageUpdate> = (ctx) => ctx.reply('bar');
+const bazMiddleware: Middleware<ContextMessageUpdate> = (ctx) => ctx.reply('baz');
+
+const otherComposer = new Composer(composer, bazMiddleware, bazMiddleware);
+Composer.compose([composer, bazMiddleware, bazMiddleware]);
+Composer.mount('callback_query', composer, bazMiddleware, bazMiddleware);
+Composer.hears('hear', composer, bazMiddleware, bazMiddleware);
+Composer.action('action', composer, bazMiddleware, bazMiddleware);
+Composer.optional(true, composer, bazMiddleware, bazMiddleware);
+Composer.branch(true, composer, bazMiddleware);
+Composer.chatType('channel', composer, bazMiddleware);
+Composer.privateChat(composer, bazMiddleware);
+Composer.groupChat(composer, bazMiddleware);
+
+composer.use(fooMiddleware, barMiddleware, otherComposer);
+composer.on('animation', barMiddleware, otherComposer);
+composer.hears('animation', barMiddleware, otherComposer);
+composer.action('animation', barMiddleware, otherComposer);
+composer.command('animation', barMiddleware, otherComposer);
+composer.gameQuery(barMiddleware, otherComposer);
+composer.start(barMiddleware, otherComposer);
+composer.help(barMiddleware, otherComposer);
+
+bot.use(composer, otherComposer, fooMiddleware);


### PR DESCRIPTION
# Description

Hi, and thank you all for this great library.

I've used the Telegraf for a while with typescript and find that typescript typings are poor.

I had two major problems with typing, 
* Custom context #920 
* pass composer as a handler #921. 

I've created this PR to cover those issues.

### Custom Context Typings

Custom context solved by adding `contextType` to `TelegrafOptions` type.  i've I've change `TelegrafOptions` to generitc type to pass `Context` to `contextType`.

(also, I found `retryAfter` and `handlerTimeout` are missing `TelegrafOptions` props)

finally, I've added `TelegrafConstructor.Context`.

### Handler Typings

For #921, I found that all middleware args can be also a `composer` too. So, I create a `Handler` type and replace it with all handler arguments in the `Composer` members. 

```typescript 
export type Handler<T extends ContextMessageUpdate> = Middleware<T> | Composer<T>

// ...

export interface Composer<TContext extends ContextMessageUpdate> {
  // ...
  use(middleware: Handler<TContext>, ...middlewares: Array<Handler<TContext>>): Telegraf<TContext>
  // ...
}
```

Fixes #920 #921 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've added all the use-cases to the `test.ts` type and it compiled successfully.

- [x] Handler Types
- [x] Custom Composer Types

**Test Configuration**:
* Node.js Version: 13.5.0
* Operating System: GNU/Linux 5.4.18
* Typescript Version: 3.0.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
