### PR TITLE
Add editMessageLiveLocation and stopMessageLiveLocation to typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -339,6 +339,22 @@ export interface ContextMessageUpdate extends Context {
   editMessageMedia(media: tt.MessageMedia ,extra?: tt.ExtraEditMessage): Promise<tt.Message | boolean>
 
   /**
+   * Use this method to edit live location messages.
+   * @returns On success, if the edited message was sent by the bot, the edited message is returned, otherwise True is returned.
+   * @param lat New latitude
+   * @param lon New longitude
+   */
+  editMessageLiveLocation(lat: number, lon: number, extra?: tt.ExtraLocation): Promise<tt.MessageLocation | boolean>
+
+  /**
+   * Use this method to stop updating a live location message before live_period expires.
+   * @returns On success, if the message was sent by the bot, the sent Message is returned, otherwise True is returned.
+   * @param extra Extra params
+   */
+  stopMessageLiveLocation(extra?: tt.ExtraLocation): Promise<tt.MessageLocation | boolean>
+
+
+  /**
    * Use this method to delete a message, including service messages, with the following limitations:
    * - A message can only be deleted if it was sent less than 48 hours ago.
    * - Bots can delete outgoing messages in groups and supergroups.

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -107,6 +107,14 @@ bot.hears('something', (ctx) => {
         reply_markup: Markup.inlineKeyboard([])
     })
 
+    ctx.editMessageLiveLocation(90,90, {
+        reply_markup: Markup.inlineKeyboard([])
+    })
+
+    ctx.stopMessageLiveLocation({
+        reply_markup: Markup.inlineKeyboard([])
+    })
+
     // tt.ExtraPhoto
     ctx.replyWithPhoto('', {
         caption: '',


### PR DESCRIPTION
# Description

I added the two function declarations editMessageLiveLocation and stopMessageLiveLocation to index.d.ts and added the use of the functions to test.ts

Fixes #923 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- `npm run test`
- `npm run typecheck`

**Test Configuration**:
* Node.js Version: v13.8.0
* Operating System: MacOS Catalina v10.15.3

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
