### PR TITLE
[TypeScript] Add types for telegram.sendVideoNote()

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -803,6 +803,15 @@ export interface Telegram {
   sendVideo(chatId: number | string, video: tt.InputFile, extra?: tt.ExtraVideo): Promise<tt.MessageVideo>
 
   /**
+   * Use this method to send video messages
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param videoNote video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data. Sending video notes by a URL is currently unsupported
+   * @param extra Additional params to send video note
+   * @returns a Message on success
+   */
+  sendVideoNote (chatId: number | string, videoNote: tt.InputFileVideoNote, extra?: tt.ExtraVideoNote): Promise<tt.MessageVideoNote>
+
+  /**
    * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
    * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
    * @param voice Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -174,6 +174,11 @@ export type InputFile =
   InputFileByBuffer |
   InputFileByURL
 
+/**
+ * Sending video notes by a URL is currently unsupported
+ */
+export type InputFileVideoNote = Exclude<InputFile, InputFileByURL>
+
 export interface ExtraReplyMessage {
 
   /**
@@ -400,6 +405,26 @@ export interface ExtraVideo extends ExtraReplyMessage {
   disable_web_page_preview?: never
 }
 
+export interface ExtraVideoNote extends ExtraReplyMessage {
+  /**
+   * Duration of sent video in seconds
+   */
+  duration?: number
+
+  /**
+   * Video width and height, i.e. diameter of the video message
+   */
+  length?: number
+
+  /**
+   * Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side.
+   * The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 320.
+   * Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file,
+   * so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>.
+   */
+  thumb?: InputFile
+}
+
 export interface ExtraVoice extends ExtraReplyMessage {
   /**
    * Voice message caption, 0-1024 characters
@@ -470,6 +495,10 @@ export interface MessageSticker extends TT.Message {
 
 export interface MessageVideo extends TT.Message {
   video: TT.Video
+}
+
+export interface MessageVideoNote extends TT.Message {
+  video_note: TT.VideoNote
 }
 
 export interface MessageVoice extends TT.Message {

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -160,6 +160,17 @@ bot.hears('something', (ctx) => {
         reply_to_message_id: 0,
         reply_markup: Markup.inlineKeyboard([])
     })
+
+    ctx.telegram.sendVideoNote(-1, "", {
+        duration: 0,
+        length: 0,
+        thumb: '',
+        parse_mode: "HTML",
+        disable_notification: false,
+        disable_web_page_preview: false,
+        reply_markup: Markup.inlineKeyboard([]),
+        reply_to_message_id: 0,
+    })
 })
 
 // Markup


### PR DESCRIPTION
# Description

Added type definitions for `telegram.sendVideoNote()` method.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```bash
npm run precommit
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
