### PR TITLE
[TypeScript] Add types for set/get MyCommands() & dice messages

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -292,6 +292,14 @@ export interface ContextMessageUpdate extends Context {
    */
   replyWithVoice(voice: tt.InputFile, extra?: tt.ExtraVoice): Promise<tt.MessageVoice>
 
+  /**
+   * Use this method to send a dice, which will have a random value from 1 to 6. On success, the sent Message is returned. (Yes, we're aware of the “proper” singular of die. But it's awkward, and we decided to help it change. One dice at a time!)
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param extra Additional params to send dice
+   * @returns a Message on success
+   */
+  replyWithDice(extra?: tt.ExtraDice): Promise<tt.MessageDice>
+
 
   // ------------------------------------------------------------------------------------------ //
   // ------------------------------------------------------------------------------------------ //
@@ -873,6 +881,14 @@ export interface Telegram {
    * @returns a Message on success
    */
   sendVoice(chatId: number | string, voice: tt.InputFile, extra?: tt.ExtraVoice): Promise<tt.MessageVoice>
+
+  /**
+   * Use this method to send a dice, which will have a random value from 1 to 6. On success, the sent Message is returned. (Yes, we're aware of the “proper” singular of die. But it's awkward, and we decided to help it change. One dice at a time!)
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param extra Additional params to send dice
+   * @returns a Message on success
+   */
+  sendDice(chatId: number | string, extra?: tt.ExtraDice): Promise<tt.MessageDice>
 
   /**
    * Use this method to specify a url and receive incoming updates via an outgoing webhook

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -949,6 +949,18 @@ export interface Telegram {
    */
   setChatTitle(chatId: number | string, title: string): Promise<boolean>;
 
+  /**
+   * Use this method to get the current list of the bot's commands. Requires no parameters.
+   * @returns Array of BotCommand on success.
+   */
+  getMyCommands(): Promise<tt.BotCommand[]>
+
+  /**
+   * Use this method to change the list of the bot's commands.
+   * @param commands A list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
+   * @returns True on success
+   */
+  setMyCommands(commands: tt.BotCommand[]): Promise<boolean>
 }
 
 export interface TelegramConstructor {

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -442,6 +442,18 @@ export interface ExtraVoice extends ExtraReplyMessage {
   disable_web_page_preview?: never
 }
 
+export interface ExtraDice extends ExtraReplyMessage {
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#senddice
+   */
+  parse_mode?: never
+  
+  /**
+   * Does not exist, see https://core.telegram.org/bots/api#senddice
+   */
+  disable_web_page_preview?: never
+}
+
 export interface IncomingMessage extends TT.Message {
   audio?: TT.Audio
   entities?: TT.MessageEntity[]
@@ -459,6 +471,7 @@ export interface IncomingMessage extends TT.Message {
   pinned_message?: TT.Message
   invoice?: TT.Invoice
   successful_payment?: TT.SuccessfulPayment
+  dice?: Dice
 }
 
 export interface MessageAudio extends TT.Message {
@@ -503,6 +516,10 @@ export interface MessageVideoNote extends TT.Message {
 
 export interface MessageVoice extends TT.Message {
   voice: TT.Voice
+}
+
+export interface MessageDice extends TT.Message {
+  dice: Dice
 }
 
 export interface NewInvoiceParams {
@@ -627,4 +644,14 @@ export interface BotCommand {
    * Description of the command, 3-256 characters.
    */
   description: string
+}
+
+/**
+ * This object represents a dice with random value from 1 to 6. (Yes, we're aware of the “proper” singular of die. But it's awkward, and we decided to help it change. One dice at a time!)
+ */
+export interface Dice {
+  /**
+   * Value of the dice, 1-6
+   */
+  value: number
 }

--- a/typings/telegram-types.d.ts
+++ b/typings/telegram-types.d.ts
@@ -613,3 +613,18 @@ export interface ExtraAnswerInlineQuery {
    */
   switch_pm_parameter?: string
 }
+
+/**
+ * This object represents a bot command
+ */
+export interface BotCommand {
+  /**
+   * Text of the command, 1-32 characters. Can contain only lowercase English letters, digits and underscores.
+   */
+  command: string
+
+  /**
+   * Description of the command, 3-256 characters.
+   */
+  description: string
+}

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -1,6 +1,7 @@
 // This is a test file for the TypeScript typings.
 // It is not intended to be used by external users.
 import Telegraf, { Markup, Middleware, ContextMessageUpdate, Extra } from './index';
+import * as tt from './telegram-types';
 
 const randomPhoto = 'https://picsum.photos/200/300/?random'
 const sayYoMiddleware: Middleware<ContextMessageUpdate> = ({ reply }, next) => reply('yo').then(() => next && next())
@@ -60,7 +61,7 @@ bot.launch({
 })
 
 // tt.ExtraXXX
-bot.hears('something', (ctx) => {
+bot.hears('something', async (ctx) => {
     // tt.ExtraReplyMessage
     ctx.reply('Response', {
         parse_mode: "Markdown",
@@ -171,6 +172,15 @@ bot.hears('something', (ctx) => {
         reply_markup: Markup.inlineKeyboard([]),
         reply_to_message_id: 0,
     })
+
+    const setMyCommandsResult: boolean =  await ctx.telegram.setMyCommands([
+        {
+            command: '',
+            description: ''
+        },
+    ])
+
+    const myCommands: tt.BotCommand[] = await ctx.telegram.getMyCommands()
 })
 
 // Markup

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -181,6 +181,18 @@ bot.hears('something', async (ctx) => {
     ])
 
     const myCommands: tt.BotCommand[] = await ctx.telegram.getMyCommands()
+
+    const messageDice: tt.MessageDice = await ctx.telegram.sendDice(0, {
+        disable_notification: false,
+        reply_markup: Markup.inlineKeyboard([]),
+        reply_to_message_id: 0
+    })
+
+    const replyWithDiceMessage: tt.MessageDice = await ctx.replyWithDice({
+        disable_notification: false,
+        reply_markup: Markup.inlineKeyboard([]),
+        reply_to_message_id: 0
+    })
 })
 
 // Markup


### PR DESCRIPTION
# Description

Added types for `setMyCommands(...)`, `getMyCommands(...)` and dice messages.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```bash
npm run precommit
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
