### PR TITLE
[TypeScript] Add typings to allow http.Agent in options

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="node" />
 
 import { IncomingMessage, ServerResponse } from 'http'
-import { Agent } from 'https'
+import * as https from 'https'
+import * as http from 'http'
 import { TlsOptions } from 'tls'
 
 import * as tt from './telegram-types.d'
@@ -11,7 +12,7 @@ export interface TelegramOptions {
   /**
    * https.Agent instance, allows custom proxy, certificate, keep alive, etc.
    */
-  agent?: Agent
+  agent?: https.Agent | http.Agent
 
   /**
    * Reply via webhook
@@ -1512,7 +1513,7 @@ export interface TOptions {
     /**
      * https.Agent instance, allows custom proxy, certificate, keep alive, etc.
      */
-    agent: Agent
+    agent: https.Agent | http.Agent
 
     /**
      * Reply via webhook

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -10,7 +10,7 @@ import * as tt from './telegram-types.d'
 
 export interface TelegramOptions {
   /**
-   * https.Agent instance, allows custom proxy, certificate, keep alive, etc.
+   * https.Agent or http.Agent instance, allows custom proxy, certificate, keep alive, etc.
    */
   agent?: https.Agent | http.Agent
 
@@ -1511,7 +1511,7 @@ export interface TOptions {
    */
   telegram?: {
     /**
-     * https.Agent instance, allows custom proxy, certificate, keep alive, etc.
+     * https.Agent or http.Agent instance, allows custom proxy, certificate, keep alive, etc.
      */
     agent: https.Agent | http.Agent
 


### PR DESCRIPTION
# Description

This allow the use of `http.Agent` in `telegram.agent`, also allows [socks-proxy-agent](https://www.npmjs.com/package/socks-proxy-agent) and probably some other agents that only support `http.Agent`'s interface.

Fixes #955

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```bash
npm run precommit
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
