### PR TITLE
Wrong order of nearby tags

### DIFF
--- a/markup.js
+++ b/markup.js
@@ -168,8 +168,13 @@ class Markup {
     entities.forEach(entity => {
       const tag = getHTMLTag(entity)
       const openPos = entity.offset
+      const secondPos = openPos + 1
       const closePos = entity.offset + entity.length + 1
-      chars[openPos] += tag.open
+      if (chars[secondPos].match(/.*(<\/.+>)/)) {
+        chars[secondPos] = chars[secondPos].replace(/.*(<\/.+>)/, `$1${tag.open}`)
+      } else {
+        chars[openPos] += tag.open
+      }
       chars[closePos] = tag.close + chars[closePos]
     })
     return chars.join('')


### PR DESCRIPTION
# Wrong order of nearby tags

Example message: 

> **foo**_bar_

Its should convert to `<b>foo</b><i>bar</i>` like this _entities_:

```
entities = [
  {
    "offset": 0,
    "length": 3,
    "type": "bold"
  },
  {
    "offset": 3,
    "length": 3,
    "type": "italic"
  }
]
```

But we have `<b>foo<i></b>bar</i>`

Fixes #983

# How Has This Been Tested?

Here is the playground for this code https://runkit.com/letitcode/telegraf-entity. But we want to change the algorithm soon.