### PR TITLE
Generate docs with typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules
 .env
 .vscode
 package-lock.json
+/telegraf-docs/

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,13 +21,13 @@ These accounts serve as an interface for code running somewhere on your server.
 #### Installation
 
 ```bash
-$ npm install telegraf --save
+npm install telegraf --save
 ```
 
 or using yarn
 
 ```bash
-$ yarn add telegraf
+yarn add telegraf
 ```
 
 #### Example
@@ -704,7 +704,7 @@ module.exports = Composer.mount(
 To run modules you can use `telegraf` module runner, it allows you to start Telegraf module easily from the command line.
 
 ```bash
-$ npm install telegraf -g
+npm install telegraf -g
 ```
 
 #### Telegraf CLI usage
@@ -739,7 +739,7 @@ module.exports = bot
 then run it:
 
 ```bash
-$ telegraf -t "bot token" bot.js
+telegraf -t "bot token" bot.js
 ```
 
 ## API reference

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-![Telegraf](header.png)
+![Telegraf](https://raw.githubusercontent.com/telegraf/telegraf/develop/docs/header.png)
 
 ## Introduction
 
@@ -709,7 +709,7 @@ npm install telegraf -g
 
 #### Telegraf CLI usage
 
-```
+```plaintext
 telegraf [opts] <bot-file>
   -t  Bot token [$BOT_TOKEN]
   -d  Webhook domain

--- a/docs/theme/assets/css/custom.css
+++ b/docs/theme/assets/css/custom.css
@@ -1,9 +1,54 @@
 /** @format */
-
 code.language-bash::before {
   content: '$';
   margin-left: 5px;
   display: inline-block;
   margin-right: 10px;
   user-select: none;
+}
+
+.tsd-navigation [href='classes/apiclient.html'],
+.tsd-navigation .tsd-kind-interface,
+.tsd-navigation .tsd-kind-type-alias {
+  display: none;
+}
+
+a > h2:hover::after,
+a > h3:hover::after,
+a > h4:hover::after,
+a > h5:hover::after {
+  content: '🔗';
+  opacity: 0.2;
+}
+
+a {
+  color: #e74625;
+}
+
+.hljs-keyword {
+  color: #07a;
+}
+
+.hljs-subst > .hljs-keyword {
+  color: inherit;
+}
+
+nav .tsd-kind-class,
+.tsd-legend > .tsd-kind-constructor,
+.tsd-legend > .tsd-kind-method,
+.tsd-index-list > .tsd-kind-class,
+.tsd-index-list > .tsd-kind-constructor,
+.tsd-index-list > .tsd-kind-method,
+.tsd-kind-constructor > .tsd-signature::before,
+.tsd-kind-method > .tsd-signature::before {
+  filter: hue-rotate(-199.8deg);
+}
+
+nav .tsd-kind-class .tsd-kind-property {
+  filter: hue-rotate(199.8deg);
+}
+
+.tsd-index-list .tsd-kind-type-alias > a,
+.tsd-index-list .tsd-kind-function > a {
+  color: #b54dff;
 }

--- a/docs/theme/assets/css/custom.css
+++ b/docs/theme/assets/css/custom.css
@@ -1,0 +1,9 @@
+/** @format */
+
+code.language-bash::before {
+  content: '$';
+  margin-left: 5px;
+  display: inline-block;
+  margin-right: 10px;
+  user-select: none;
+}

--- a/docs/theme/layouts/default.hbs
+++ b/docs/theme/layouts/default.hbs
@@ -1,0 +1,55 @@
+<!doctype html>
+<html class="default no-js">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>{{#ifCond model.name '==' project.name}}{{project.name}}{{else}}{{model.name}} | {{project.name}}{{/ifCond}}
+  </title>
+  <meta name="description" content="Documentation for {{project.name}}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <link rel="stylesheet" href="{{relativeURL "assets/css/main.css"}}">
+  <link rel="stylesheet" href="{{relativeURL "assets/css/custom.css"}}">
+</head>
+
+<body>
+
+  {{> header}}
+
+  <div class="container container-main">
+    <div class="row">
+      <div class="col-8 col-content">
+        {{{contents}}}
+      </div>
+      <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
+        <nav class="tsd-navigation primary">
+          <ul>
+            {{#each navigation.children}}
+            {{> navigation}}
+            {{/each}}
+          </ul>
+        </nav>
+
+        <nav class="tsd-navigation secondary menu-sticky">
+          <ul class="before-current">
+            {{#each toc.children}}
+            {{> toc.root}}
+            {{/each}}
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+
+  {{> footer}}
+
+  <div class="overlay"></div>
+  <script src="{{relativeURL "assets/js/main.js"}}"></script>
+  <script>if (location.protocol == 'file:') document.write('<script src="{{relativeURL "assets/js/search.js"}}"><' + '/script>');</script>
+
+  {{> analytics}}
+
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint .",
     "test": "ava test/*",
     "precommit": "npm run lint && npm run typecheck && npm test",
+    "typedoc": "typedoc",
     "typecheck": "tsc"
   },
   "type": "commonjs",
@@ -54,6 +55,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "husky": "^4.2.0",
     "prettier": "^2.0.5",
+    "typedoc": "^0.17.4",
     "typescript": "^3.0.1"
   },
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,14 @@
     "noEmit": true,
     "forceConsistentCasingInFileNames": true
   },
+  "typedocOptions": {
+    "exclude": ["typings/test.ts"],
+    "excludeExternals": true,
+    "includeDeclarations": true,
+    "mode": "file",
+    "out": "telegraf-docs",
+    "readme": "docs/README.md"
+  },
   "include": [
     "typings"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "includeDeclarations": true,
     "mode": "file",
     "out": "telegraf-docs",
-    "readme": "docs/README.md"
+    "readme": "docs/README.md",
+    "theme": "docs/theme/"
   },
   "include": [
     "typings"


### PR DESCRIPTION
# Description

Documentation (#211) and typings (#979) are known to be lacking, so why not kill two birds with one stone by improving the typings and generating API reference from them?

Current output: https://telegraf-docs.now.sh.

This requires rethinking how docs are published, hence just a draft.

cc @YouTwitFace

## Type of change

- Documentation (typos, code examples or any documentation update)
- This change requires a documentation update
