### PR TITLE
[fix] sending options to `new Telegram()`

### DIFF
--- a/telegraf.js
+++ b/telegraf.js
@@ -44,7 +44,7 @@ class Telegraf extends Composer {
   set token (token) {
     this.telegram = new Telegram(token, this.telegram
       ? this.telegram.options
-      : this.options.telegram
+      : this.options
     )
   }
 


### PR DESCRIPTION
# Description

Problem - couldnt to set custom apiRoot
typo mistake on sending options

Fixes # (issue)

## Type of change
typo mistake

- [ x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

```
new Telegraf(token, { apiRoot: 'http://custom.url' });

// core/network/client.js
229 line:
console.log(this.options);
// expect that apiRoot is custom.url
```

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Node.js Version: 12.14.1
* Operating System: macos catalina

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
