### PR TITLE
Stage allows empty constructor

### DIFF
--- a/typings/stage.d.ts
+++ b/typings/stage.d.ts
@@ -82,7 +82,7 @@ export type StageOptions = SceneContextOptions
 export class Stage<TContext extends SceneContextMessageUpdate> extends Composer<
   TContext
 > {
-  constructor(scenes: Scene<TContext>[], options?: Partial<StageOptions>)
+  constructor(scenes?: Scene<TContext>[], options?: Partial<StageOptions>)
 
   register: (...scenes: Scene<TContext>[]) => this
 


### PR DESCRIPTION
Scenes is optional, you can use register after the empty constructor, so it should be optional the parameter.

- [ ] Documentation (typos, code examples or any documentation update)
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
