### PR TITLE
Add MarkdownV2 to Extras

### DIFF
--- a/extra.js
+++ b/extra.js
@@ -41,6 +41,11 @@ class Extra {
     this.parse_mode = value ? 'Markdown' : undefined
     return this
   }
+  
+  markdownv2 (value = true) {
+    this.parse_mode = value ? 'MarkdownV2' : undefined
+    return this
+  }
 
   caption (caption = '') {
     this.caption = caption
@@ -73,6 +78,10 @@ class Extra {
 
   static markdown (value) {
     return new Extra().markdown(value)
+  }
+
+  static markdownv2(value) {
+    return new Extra().markdownv2(value)
   }
 
   static caption (caption) {


### PR DESCRIPTION
# Description

This adds MarkdownV2 to telegraf/extras

## Type of change
Currently only `Extra.markdown()` is possible, there's no direct support for MarkdownV2 in Extras

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tried sending a message with `MarkdownV2` parse_mode and can confirm i can use all basic markdown plus nested markdown too (only a feature of v2)
![image](https://user-images.githubusercontent.com/3626859/83962916-4353b280-a8bf-11ea-8961-fcd9e8a76c52.png)



**Test Configuration**:
* Node.js Version: v14.1.0
* Operating System: Windows 10 x64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
