### PR TITLE
Add MineTelegram to the Community bots

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ For additional bot examples see [`examples`](https://github.com/telegraf/telegra
 | [NodeRSSBot](https://github.com/fengkx/NodeRSSBot) | Bot to subscribe RSS feed which allows many configurations |
 | [BibleBot](https://github.com/Kriv-Art/BibleBot) | Bot to get bible verses |
 | [BitcoinDogBot](https://github.com/jibital/bitcoin-dog-bot) | Bitcoin prices, Technical analysis and Alerts! |
+| [MineTelegram](https://github.com/hexatester/minetelegram) | Minecraft - Telegram bridge |
 | Send PR to add link to your bot |   |
 
 ## Getting started


### PR DESCRIPTION
Minetelegram, mainly used as chat.

# Description

Add minetegram to the community bots.

## Type of change

Please delete options that are not relevant.

- [*] Documentation (typos, code examples or any documentation update)

