### PR TITLE
Telegraf import modules example with ES6 syntax

### DIFF
--- a/docs/examples/echo-bot.js
+++ b/docs/examples/echo-bot.js
@@ -1,6 +1,12 @@
-const Telegraf = require('telegraf')
-const Extra = require('telegraf/extra')
-const Markup = require('telegraf/markup')
+// Normal Node.js syntax
+// const Telegraf = require('telegraf')
+// const Extra = require('telegraf/extra')
+// const Markup = require('telegraf/markup')
+
+// This is way these modules should be imported with the new ES6 syntax
+import Telegraf from 'telegraf';
+import Extra from 'telegraf/extra.js';
+import Markup from 'telegraf/markup.js';
 
 const keyboard = Markup.inlineKeyboard([
   Markup.urlButton('❤️', 'http://telegraf.js.org'),


### PR DESCRIPTION
Example of how to import Telefraf modules with the new ES6 syntax

# Description

This is an example of how to import Telefraf modules with the new ES6 syntax

## Type of change

Please delete options that are not relevant.

- [ X ] Documentation (typos, code examples or any documentation update)
- [ X ] This change requires a documentation update

# How Has This Been Tested?

You can test new ES6 syntax WITHOUT using Babel or any other transpiler with Node version >= 12 and applying the following changes to your project:

- [ X ] Rename your files from myTelegrafBot.js to myTelegrafBot.mjs
- [ X ] Execute node with the following flag --experimental-modules

**Test Configuration**:
* Node.js Version: >= 12
* Operating System: Linux, Mac

# Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
