### PR TITLE
Clarify docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,11 @@ Bots are special [Telegram](https://telegram.org) accounts designed to handle me
 Users can interact with bots by sending them command messages in private or group chats. 
 These accounts serve as an interface for code running somewhere on your server.
 
+Telegraf is a library that makes it simple for you to develop your own Telegram bots using JavaScript or [TypeScript](https://www.typescriptlang.org/).
+
 #### Features
 
-- Full [Telegram Bot API 4.8](https://core.telegram.org/bots/api) support
+- Full [Telegram Bot API 4.9](https://core.telegram.org/bots/api) support
 - [Telegram Payment Platform](https://telegram.org/blog/payments)
 - [HTML5 Games](https://core.telegram.org/bots/api#games)
 - [Inline mode](https://core.telegram.org/bots/api#inline-mode)
@@ -132,7 +134,7 @@ BotFather will give you a *token*, something like `123456789:AbCdfGhIJKlmNoQQRsT
 
 A Telegraf bot is an object containing an array of middlewares which are composed 
 and executed in a stack-like manner upon request. Is similar to many other middleware systems 
-that you may have encountered such as Koa, Ruby's Rack, Connect.
+that you may have encountered such as Express, Koa, Ruby's Rack, Connect.
 
 #### Middleware
 
@@ -141,9 +143,19 @@ It allows you to modify requests and responses as they pass between the Telegram
 
 You can imagine middleware as a chain of logic connection your bot to the Telegram request.
 
-Middleware normally takes two parameters (ctx, next), `ctx` is the context for one Telegram update, 
-`next` is a function that is invoked to execute the downstream middleware. 
-It returns a Promise with a then function for running code after completion.
+Middleware normally takes the two parameters: **`ctx`** and **`next`**.
+
+**`ctx`** is the context for one [Telegram update](https://core.telegram.org/bots/api#update). It contains mainly two things:
+
+- the update object, it contains for example the incoming message and the respective the chat, and
+- a number of useful methods for reacting to the update, such as replying to the message or answering a callback query.
+
+See  [the context section](https://telegraf.js.org/#/?id=context) below for a detailed overview.
+
+**`next`** is a function that is invoked to execute the downstream middleware.
+It returns a `Promise` with a function `then` for running code after completion.
+
+Here is a simple example for how to use middleware to track the response time, using `async` and `await` to deal with the `Promise`.
 
 ```js
 const bot = new Telegraf(process.env.BOT_TOKEN)
@@ -159,18 +171,36 @@ bot.on('text', (ctx) => ctx.reply('Hello World'))
 bot.launch()
 ```
 
+Note how the function `next` is used to invoke the subsequent layers of the middleware stack, performing the actual processing of the update (in this case, replying with “Hello World”).
+
+##### What you can do with middleware
+
+Middleware is an extremely flexible concept that can be used for a myriad of things, including these:
+
+- storing data per chat, per user, you name it
+- allowing access to old messages (by storing them)
+- making internationalization available
+- rate limiting
+- tracking response times (see above)
+- much more
+
+All important kinds of middleware have already been implemented, and the community keeps on adding more.
+Just install a package via `npm`, add it to your bot and you're ready to go.
+
+Here is a list of
+
 ##### Known middleware
 
-- [Internationalization](https://github.com/telegraf/telegraf-i18n)
-- [Redis powered session](https://github.com/telegraf/telegraf-session-redis)
-- [Local powered session (via lowdb)](https://github.com/RealSpeaker/telegraf-session-local)
-- [Rate-limiting](https://github.com/telegraf/telegraf-ratelimit)
-- [Bottleneck powered throttling](https://github.com/KnightNiwrem/telegraf-throttler)
-- [Menus via inline keyboards](https://github.com/EdJoPaTo/telegraf-inline-menu)
-- [Stateless Questions](https://github.com/EdJoPaTo/telegraf-stateless-question)
+- [Internationalization](https://github.com/telegraf/telegraf-i18n)—simplifies selecting the right translation to use when responding to a user.
+- [Redis powered session](https://github.com/telegraf/telegraf-session-redis)—store session data using Redis.
+- [Local powered session (via lowdb)](https://github.com/RealSpeaker/telegraf-session-local)—store session data in a local file.
+- [Rate-limiting](https://github.com/telegraf/telegraf-ratelimit)—apply rate limitting to chats or users.
+- [Bottleneck powered throttling](https://github.com/KnightNiwrem/telegraf-throttler)—apply throttling to both incoming updates and outgoing API calls.
+- [Menus via inline keyboards](https://github.com/EdJoPaTo/telegraf-inline-menu)—simplify creating interfaces based on menus.
+- [Stateless Questions](https://github.com/EdJoPaTo/telegraf-stateless-question)—create stateless questions to Telegram users working in privacy mode.
 - [Natural language processing via wit.ai](https://github.com/telegraf/telegraf-wit)
 - [Natural language processing via recast.ai](https://github.com/telegraf/telegraf-recast)
-- [Multivariate and A/B testing](https://github.com/telegraf/telegraf-experiments)
+- [Multivariate and A/B testing](https://github.com/telegraf/telegraf-experiments)—add experiments to see how different versions of a feature are used.
 - [Powerfull bot stats via Mixpanel](https://github.com/telegraf/telegraf-mixpanel)
 - [statsd integration](https://github.com/telegraf/telegraf-statsd)
 - [and more...](https://www.npmjs.com/search?q=telegraf-)
@@ -179,7 +209,7 @@ bot.launch()
 
 By default Telegraf will print all errors to `stderr` and rethrow error.
 
-To perform custom error-handling logic use following snippet:
+To perform custom error-handling logic, use following snippet:
 
 ```js
 const bot = new Telegraf(process.env.BOT_TOKEN)
@@ -242,6 +272,9 @@ bot.on('text', (ctx) => {
 
 bot.launch()
 ```
+
+If you're using TypeScript, have a look at the section below about usage with TypeScript.
+(You need to extend the type of the context.)
 
 ##### Shortcuts
 
@@ -428,6 +461,24 @@ bot.launch()
 
 #### Session
 
+Sessions are used to store data per user or per chat (or per whatever if you want, this is the *session key*).
+
+Think of a session as an object that can hold any kind of information you provide.
+This could be the ID of the last message of the bot, or simply a counter about how many photos a user already sent to the bot.
+
+You can use session middleware to add sessions support to your bot.
+This will do the heavy lifting for you.
+Using session middleware will result in a sequence like this:
+
+1) A new update comes in.
+2) The session middleware loads the current session data for the respective chat/user/whatever.
+3) The session middleware makes that session data available on the context object `ctx`.
+4) Your middleware stack is run, all of your code can do its work.
+5) The session middleware takes back control and checks how you altered the session data on the `ctx` object.
+6) The session middleware write the session back to your storage, i.e. a file, a database, an in-memory storage, or even a cloud storage solution.
+
+Here is a simple example of how the built-in session middleware of Telegraf can be used to count photos.
+
 ```js
 const session = require('telegraf/session')
 
@@ -441,6 +492,10 @@ bot.on('text', (ctx) => {
 
 bot.launch()
 ```
+
+In this example, the session middleware just stores the counters in-memory.
+This means that all counters will be lost when you stop your bot.
+If you want to store data even across restarts, you need to use *persistent sessions*.
 
 **Note: For persistent sessions you can use any of [`telegraf-session-*`](https://www.npmjs.com/search?q=telegraf-session) middleware.**
 
@@ -460,6 +515,8 @@ bot.launch()
 ```
 
 #### Update types
+
+You can react to several different types of updates (and even sub-types of them), see the example below.
 
 Supported update types:
 
@@ -551,7 +608,7 @@ bot.startWebhook('/secret-path', tlsOptions, 8443)
 bot.startWebhook('/secret-path', null, 5000)
 ```
 
-Use webhookCallback() if you want to attach telegraf to existing http server
+Use `webhookCallback()` if you want to attach Telegraf to an existing http server.
 
 ```js
 require('http')
@@ -638,7 +695,7 @@ Supported file sources:
 - `Buffer`
 - `ReadStream`
 
-Also you can provide optional name of file as `filename`.
+Also, you can provide an optional name of a file as `filename` when you send the file.
 
 ```js
 bot.on('message', (ctx) => {
@@ -693,7 +750,7 @@ bot.on('passport_data', (ctx) => {
 
 Telegraf Modules is higher level abstraction for writing modular Telegram bots.
 
-Module is simple js file with exported Telegraf middleware:
+A module is simply a .js file that exports Telegraf middleware:
 
 ```js
 module.exports = (ctx) => ctx.reply('Hello from Telegraf Module!')
@@ -708,7 +765,7 @@ module.exports = Composer.mount(
 )
 ```
 
-To run modules you can use `telegraf` module runner, it allows you to start Telegraf module easily from the command line.
+To run modules, you can use `telegraf` module runner, it allows you to start Telegraf module easily from the command line.
 
 ```bash
 npm install telegraf -g
@@ -752,7 +809,7 @@ telegraf -t "bot token" bot.js
 #### Usage with TypeScript
 
 Telegraf is written in TypeScript and therefore ships with declaration files for the entire library.
-Moreover, it includes types for the complete Telegram API via the `typegram` package.
+Moreover, it includes types for the complete Telegram API via the [`typegram`](https://github.com/KnorpelSenf/typegram) package.
 While most types of Telegraf's API surface are self-explanatory, there's some notable things to keep in mind.
 
 ##### Custom Context Type and Middleware


### PR DESCRIPTION
# Description

A number of things really confused me back in the days when I got started with Telegraf.
This PR elaborates on those points that might not be self-explanatory to newcomers, especially not if they're yet inexperienced with request/response systems in general and middleware, sessions, and so on in particular. Sketching what these terms mean helps a lot compared to just throwing a bunch of code at them.

Contains a few fixes for typos, too.

Updates the supported version of the Telegram API to 4.9. I checked if that's true and I think it is, but please verify this before merging.

Fixes #971
Fixes #1007
Fixes #1077
Relates to #211

## Type of change

Please delete options that are not relevant.

- [X] Documentation (typos, code examples or any documentation update)