### PR TITLE
Re-enable short middleware notation

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -643,9 +643,7 @@ export class Composer<TContext extends Context>
       return await execute(0, ctx)
       async function execute(i: number, context: TContext): Promise<unknown> {
         if (!(context instanceof Context)) {
-          return await Promise.reject(
-            new Error('next(ctx) called with invalid context')
-          )
+          throw new Error('next(ctx) called with invalid context')
         }
         if (i <= index) {
           return await Promise.reject(new Error('next() called multiple times'))

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -638,9 +638,9 @@ export class Composer<TContext extends Context>
     if (middlewares.length === 1) {
       return Composer.unwrap(middlewares[0])
     }
-    return async (ctx, next) => {
+    return (ctx, next) => {
       let index = -1
-      return await execute(0, ctx)
+      return execute(0, ctx)
       async function execute(i: number, context: TContext): Promise<void> {
         if (!(context instanceof Context)) {
           throw new Error('next(ctx) called with invalid context')

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -653,15 +653,9 @@ export class Composer<TContext extends Context>
         if (!handler) {
           return
         }
-        try {
-          return await Promise.resolve(
-            handler(context, async (ctx = context) => {
-              await execute(i + 1, ctx)
-            })
-          )
-        } catch (err) {
-          return await Promise.reject(err)
-        }
+        await handler(context, async (ctx = context) => {
+          await execute(i + 1, ctx)
+        })
       }
     }
   }

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -653,7 +653,7 @@ export class Composer<TContext extends Context>
         index = i
         const handler = middlewares[i] ? Composer.unwrap(middlewares[i]) : next
         if (!handler) {
-          return await Promise.resolve()
+          return
         }
         try {
           return await Promise.resolve(

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -641,12 +641,12 @@ export class Composer<TContext extends Context>
     return async (ctx, next) => {
       let index = -1
       return await execute(0, ctx)
-      async function execute(i: number, context: TContext): Promise<unknown> {
+      async function execute(i: number, context: TContext): Promise<void> {
         if (!(context instanceof Context)) {
           throw new Error('next(ctx) called with invalid context')
         }
         if (i <= index) {
-          return await Promise.reject(new Error('next() called multiple times'))
+          throw new Error('next() called multiple times')
         }
         index = i
         const handler = middlewares[i] ? Composer.unwrap(middlewares[i]) : next

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export namespace Middleware {
   export type Fn<TContext extends Context> = (
     ctx: TContext,
     next: () => Promise<void>
-  ) => Promise<void>
+  ) => unknown
   export interface Obj<TContext extends Context> {
     middleware: () => Fn<TContext>
   }
@@ -22,7 +22,7 @@ export namespace Middleware {
   >(
     ctx: TContext,
     next: (ctx: Extension & TContext) => Promise<void>
-  ) => Promise<void>
+  ) => unknown
   export type Ext<
     BaseContext extends Context,
     Extension extends object

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,8 @@ export namespace Middleware {
   export type Fn<TContext extends Context> = (
     ctx: TContext,
     next: () => Promise<void>
-  ) => unknown
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  ) => Promise<unknown> | void
   export interface Obj<TContext extends Context> {
     middleware: () => Fn<TContext>
   }
@@ -22,7 +23,8 @@ export namespace Middleware {
   >(
     ctx: TContext,
     next: (ctx: Extension & TContext) => Promise<void>
-  ) => unknown
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  ) => Promise<unknown> | void
   export type Ext<
     BaseContext extends Context,
     Extension extends object

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,5 +35,4 @@ export type Middleware<TContext extends Context> =
 
 export type NonemptyReadonlyArray<T> = readonly [T, ...T[]]
 
-// prettier-ignore
 export type Tail<T> = T extends [unknown, ...infer U] ? U : never


### PR DESCRIPTION
# Description

With the current version of the code base, it is not possible to write something like this:

```ts
bot.on('photo', ctx => {
  ctx.session.counter ??= 0
  ctx.session.counter++
})
```

Middleware is required to return `Promise<void>`. It cannot return `void`. This is nasty. It requires the counterintuitive

```ts
bot.on('photo', async ctx => {
  ctx.session.counter ??= 0
  ctx.session.counter++
})
```
with an `async` middleware that does not even use `await`.

Furthermore, with the current codebase, it is not possible to write something like this:

```ts
bot.command('start', ({ reply }) => reply('Welcome! I count your photos. /help'))
```

The problem is that middleware must return `Promise<void>`, so even adding `async` and `await` does not work here.
We have to allow returning arbitrary values from the middleware function in order to allow this convenient pattern.
Otherwise, strange workarounds like this would be necessary:

```ts
bot.command('start', async ({ reply }) => void reply('Welcome! I count your photos. /help'))
// or even
bot.command('start', async ({ reply }) => {
  reply('Welcome! I count your photos. /help')
})
```

Fixes the above issue.

May help with
- #1110 
- #1128

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`npm t && npm run typecheck`

This PR is a result of the test development performed after https://github.com/telegraf/telegraf/pull/1134#issuecomment-708249167

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
