### PR TITLE
Potentially improve stacktraces by moving to async/await

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -3,7 +3,6 @@
 import * as tt from './telegram-types'
 import { Middleware, NonemptyReadonlyArray } from './types'
 import Context from './context'
-import { hasProp } from './core/helpers/check'
 
 type MaybeArray<T> = T | T[]
 type MaybePromise<T> = T | Promise<T>
@@ -160,9 +159,8 @@ export class Composer<TContext extends Context>
   ) {
     const handler = Composer.compose(fns)
     return this.command('start', (ctx, next) => {
-      const startPayload = hasProp(ctx.message, 'text')
-        ? ctx.message.text.substring(7)
-        : ''
+      // @ts-expect-error we know that ctx.message.text !== undefined but TypeScript does not
+      const startPayload = ctx.message.text.substring(7)
       return handler(Object.assign(ctx, { startPayload }), next)
     })
   }

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -3,6 +3,7 @@
 import * as tt from './telegram-types'
 import { Middleware, NonemptyReadonlyArray } from './types'
 import Context from './context'
+import { hasProp } from './core/helpers/check'
 
 type MaybeArray<T> = T | T[]
 type MaybePromise<T> = T | Promise<T>
@@ -159,8 +160,9 @@ export class Composer<TContext extends Context>
   ) {
     const handler = Composer.compose(fns)
     return this.command('start', (ctx, next) => {
-      // @ts-expect-error
-      const startPayload = ctx.message.text.substring(7)
+      const startPayload = hasProp(ctx.message, 'text')
+        ? ctx.message.text.substring(7)
+        : ''
       return handler(Object.assign(ctx, { startPayload }), next)
     })
   }
@@ -320,7 +322,7 @@ export class Composer<TContext extends Context>
     const updateTypes = normalizeTextArguments(updateType)
     const predicate = (ctx: TContext) =>
       updateTypes.includes(ctx.updateType) ||
-      // @ts-expect-error
+      // @ts-expect-error `type` is a string and not a union of literals
       updateTypes.some((type) => ctx.updateSubTypes.includes(type))
     return Composer.optional(predicate, ...fns)
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -42,7 +42,7 @@ export class Router<TContext extends Context>
   }
 
   middleware() {
-    return Composer.lazy<TContext>(async (ctx) => {
+    return Composer.lazy<TContext>((ctx) => {
       const result = this.routeFn(ctx)
       if (result == null) {
         return this.otherwiseHandler

--- a/src/router.ts
+++ b/src/router.ts
@@ -42,15 +42,14 @@ export class Router<TContext extends Context>
   }
 
   middleware() {
-    return Composer.lazy<TContext>((ctx) => {
-      return Promise.resolve(this.routeFn(ctx)).then((result) => {
-        if (result == null) {
-          return this.otherwiseHandler
-        }
-        Object.assign(ctx, result.context)
-        Object.assign(ctx.state, result.state)
-        return this.handlers.get(result.route) ?? this.otherwiseHandler
-      })
+    return Composer.lazy<TContext>(async (ctx) => {
+      const result = this.routeFn(ctx)
+      if (result == null) {
+        return this.otherwiseHandler
+      }
+      Object.assign(ctx, result.context)
+      Object.assign(ctx.state, result.state)
+      return this.handlers.get(result.route) ?? this.otherwiseHandler
     })
   }
 }

--- a/src/scenes/context.ts
+++ b/src/scenes/context.ts
@@ -56,8 +56,9 @@ class SceneContext<TContext extends Context> {
     if (!this.scenes.has(sceneId)) {
       throw new Error(`Can't find scene: ${sceneId}`)
     }
-    const leave = silent ? noop() : this.leave()
-    await leave
+    if (!silent) {
+      await this.leave()
+    }
     debug('Enter scene', sceneId, initialState, silent)
     this.session.current = sceneId
     this.state = initialState

--- a/src/scenes/context.ts
+++ b/src/scenes/context.ts
@@ -73,7 +73,7 @@ class SceneContext<TContext extends Context> {
       typeof this.current.enterMiddleware === 'function'
         ? this.current.enterMiddleware()
         : this.current.middleware()
-    return handler(this.ctx, noop)
+    return await handler(this.ctx, noop)
   }
 
   reenter() {

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -21,12 +21,13 @@ class Telegram extends ApiClient {
   /**
    * Get download link to a file
    */
-  async getFileLink(
-    fileId: string | tt.File | Promise<string> | Promise<tt.File>
-  ) {
-    fileId = await fileId
-    if (typeof fileId === 'string') return await this.getFile(fileId)
-    if (fileId.file_path !== undefined) return fileId
+  async getFileLink(fileId: string | tt.File) {
+    if (typeof fileId === 'string') {
+      return await this.getFile(fileId)
+    }
+    if (fileId.file_path !== undefined) {
+      return fileId
+    }
     const file = await this.getFile(fileId.file_id)
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     return `${this.options.apiRoot}/file/bot${this.token}/${file.file_path}`

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -23,14 +23,12 @@ class Telegram extends ApiClient {
    */
   async getFileLink(fileId: string | tt.File) {
     if (typeof fileId === 'string') {
-      return await this.getFile(fileId)
+      fileId = await this.getFile(fileId)
+    } else if (fileId.file_path === undefined) {
+      fileId = await this.getFile(fileId.file_id)
     }
-    if (fileId.file_path !== undefined) {
-      return fileId
-    }
-    const file = await this.getFile(fileId.file_id)
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    return `${this.options.apiRoot}/file/bot${this.token}/${file.file_path}`
+    return `${this.options.apiRoot}/file/bot${this.token}/${fileId.file_path}`
   }
 
   getUpdates(

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -21,18 +21,15 @@ class Telegram extends ApiClient {
   /**
    * Get download link to a file
    */
-  getFileLink(fileId: string | tt.File) {
-    return Promise.resolve(fileId)
-      .then((fileId) => {
-        if (typeof fileId === 'string') return this.getFile(fileId)
-        if (fileId.file_path !== undefined) return fileId
-        return this.getFile(fileId.file_id)
-      })
-      .then(
-        (file) =>
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          `${this.options.apiRoot}/file/bot${this.token}/${file.file_path}`
-      )
+  async getFileLink(
+    fileId: string | tt.File | Promise<string> | Promise<tt.File>
+  ) {
+    fileId = await fileId
+    if (typeof fileId === 'string') return await this.getFile(fileId)
+    if (fileId.file_path !== undefined) return fileId
+    const file = await this.getFile(fileId.file_id)
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    return `${this.options.apiRoot}/file/bot${this.token}/${file.file_path}`
   }
 
   getUpdates(


### PR DESCRIPTION
# Description

The `async`/`await` pattern can sometimes improve stack traces. However, it is not applied consistently in the library. This PR performs some automatic code transformations to reasonable places such that `async`/`await` is used instead of `Promise`s.

(Also, two  `ts-expect-error` comments were explained with a comment each.)

## Type of change

- [X] Could make future stack traces more readable, does not introduce functional changes

# How Has This Been Tested?

`npm run lint && npm t`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
