### PR TITLE
[docs] use fastify-telegraf

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -622,7 +622,7 @@ require('https')
   .listen(8443)
 ```
 
-Express.js example integration
+##### Express.js example integration
 
 ```js
 const { Telegraf } = require('telegraf')
@@ -642,16 +642,20 @@ expressApp.listen(3000, () => {
 })
 ```
 
-Fastify example integration
+##### Fastify example integration
+
+You can use `fastify-telegraf` package
 
 ```js
 const { Telegraf } = require('telegraf')
 const fastifyApp = require('fastify')()
+const fastifyTelegraf = require('fastify-telegraf')
 
 const bot = new Telegraf(process.env.BOT_TOKEN)
 
 bot.on('text', ({ reply }) => reply('Hello'))
-fastifyApp.use(bot.webhookCallback('/secret-path'))
+
+fastifyApp.register(fastifyTelegraf, { bot, path: '/secret-path' })
 // Set telegram webhook
 // npm install -g localtunnel && lt --port 3000
 bot.telegram.setWebhook('https://------.localtunnel.me/secret-path')
@@ -661,7 +665,7 @@ fastifyApp.listen(3000, () => {
 })
 ```
 
-Koa.js example integration
+##### Koa.js example integration
 
 ```js
 const { Telegraf } = require('telegraf')

--- a/docs/examples/fastify-webhook-bot.js
+++ b/docs/examples/fastify-webhook-bot.js
@@ -1,15 +1,25 @@
-const Telegraf = require('telegraf')
-const fastifyApp = require('fastify')()
+const fastify = require('fastify')
+const { Telegraf } = require('telegraf')
+const telegrafPlugin = require('fastify-telegraf')
 
-const bot = new Telegraf(process.env.BOT_TOKEN)
+const { BOT_TOKEN, WEBHOOK_URL } = process.env
+const PORT = process.env.PORT || 3000
+const SECRET_PATH = '/my-secret-path'
+
+if (!WEBHOOK_URL) throw new Error('"WEBHOOK_URL" env var is required!')
+if (!BOT_TOKEN) throw new Error('"BOT_TOKEN" env var is required!')
+
+const bot = new Telegraf(BOT_TOKEN)
+const app = fastify()
+
+app.register(telegrafPlugin, { bot, path: SECRET_PATH })
 
 bot.on('text', ({ reply }) => reply('Hello'))
 
-// Set telegram webhook
-// npm install -g localtunnel && lt --port 3000
-bot.telegram.setWebhook('https://-------.localtunnel.me/secret-path')
+bot.telegram.setWebhook(WEBHOOK_URL).then(() => {
+  console.log('Webhook is set on', WEBHOOK_URL)
+})
 
-fastifyApp.use(bot.webhookCallback('/secret-path'))
-fastifyApp.listen(3000, () => {
-  console.log('Example app listening on port 3000!')
+app.listen(PORT, () => {
+  console.log('Start listening on port', PORT)
 })


### PR DESCRIPTION
After version 3 of fastify, fastify-team decided not to support express-like middlewares out of the box (for performance reason and ...), so express-like middleware are not available without using third-party modules.

I created this tiny plugin [fastify-telegraf](https://github.com/erfanium/fastify-telegraf) that easly integrates telegraf with fastify without need to install any express-like middleware engines for fastify, Much better and faster than other ways
 
## Type of change

- [x] Documentation (typos, code examples or any documentation update)