### PR TITLE
Fix telegram.getFileLink with local bot API instances

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1748,7 +1748,7 @@ Returns basic info about a file and prepare it for downloading.
 
 ##### getFileLink
 
-Returns link or path to file.
+Returns link to file.
 
 `telegram.getFileLink(fileId) => Promise`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1748,7 +1748,7 @@ Returns basic info about a file and prepare it for downloading.
 
 ##### getFileLink
 
-Returns link to file.
+Returns link or path to file.
 
 `telegram.getFileLink(fileId) => Promise`
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -31,7 +31,7 @@ class Telegram extends ApiClient {
 
     // Local bot API instances return the absolute path to the file
     if (fileId.file_path && isAbsolute(fileId.file_path)) {
-      return 'file://' + fileId.file_path
+      return new URL(fileId.file_path.replace(/^\/?/, '/'), 'file:')
     }
 
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -19,7 +19,7 @@ class Telegram extends ApiClient {
   }
 
   /**
-   * Get download link or path to a file
+   * Get download link to a file
    */
   async getFileLink(fileId: string | tt.File) {
     if (typeof fileId === 'string') {

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,6 +1,7 @@
 import * as replicators from './core/replicators'
 import * as tt from './telegram-types'
 import ApiClient from './core/network/client'
+import { isAbsolute } from 'path'
 
 class Telegram extends ApiClient {
   /**
@@ -29,7 +30,7 @@ class Telegram extends ApiClient {
     }
 
     // Local bot API instances return the absolute path to the file
-    if (fileId.file_path?.startsWith('/')) {
+    if (fileId.file_path && isAbsolute(fileId.file_path)) {
       return fileId.file_path
     }
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -19,7 +19,7 @@ class Telegram extends ApiClient {
   }
 
   /**
-   * Get download link to a file
+   * Get download link or path to a file
    */
   async getFileLink(fileId: string | tt.File) {
     if (typeof fileId === 'string') {
@@ -27,6 +27,12 @@ class Telegram extends ApiClient {
     } else if (fileId.file_path === undefined) {
       fileId = await this.getFile(fileId.file_id)
     }
+
+    // Local bot API instances return the absolute path to the file
+    if (fileId.file_path?.startsWith('/')) {
+      return fileId.file_path
+    }
+
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     return `${this.options.apiRoot}/file/bot${this.token}/${fileId.file_path}`
   }


### PR DESCRIPTION
# Description

Local bot API instances return the absolute path to the file and `getFileLink` breaks since it adds `{apiRoot}/file/bot{token}/` to the path

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples or any documentation update)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes