### PR TITLE
Add build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ node_modules
 /telegraf-docs/
 /typings/
 tsconfig.tsbuildinfo
+
+# Linting cache
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "typecheck": "npm run typecheck:lib && npm run typecheck:docs",
     "typecheck:lib": "tsc --noEmit",
     "typecheck:docs": "tsc --build docs/examples",
+    "pretest": "npm run build:lib",
     "test": "ava test/*",
     "lint": "eslint .",
     "clean": "git clean -fX docs/build/ lib/ typings/"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,17 @@
     "telegraf": "./bin/telegraf"
   },
   "scripts": {
-    "lint": "eslint .",
-    "pretest": "tsc --build docs/examples",
+    "pretest": "npm run typecheck",
+    "prepare": "npm run build",
+    "build": "npm run build:lib && npm run build:docs",
+    "build:lib": "tsc && mjs-entry src/index.ts > lib/index.mjs",
+    "build:docs": "typedoc",
+    "typecheck": "npm run typecheck:lib && npm run typecheck:docs",
+    "typecheck:lib": "tsc --noEmit",
+    "typecheck:docs": "tsc --build docs/examples",
     "test": "ava test/*",
-    "typedoc": "typedoc",
-    "clean": "git clean -fX docs/build/ lib/ typings/",
-    "typecheck": "tsc --noEmit",
-    "prepare": "tsc && mjs-entry src/index.ts >lib/index.mjs"
+    "lint": "eslint .",
+    "clean": "git clean -fX docs/build/ lib/ typings/"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "telegraf": "./bin/telegraf"
   },
   "scripts": {
-    "prepare": "npm run build && npm run build:docs && mjs-entry src/index.ts > lib/index.mjs",
+    "prepare": "npm run build && mjs-entry src/index.ts > lib/index.mjs",
     "build": "tsc --build docs/examples",
     "build:docs": "typedoc",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,13 @@
     "telegraf": "./bin/telegraf"
   },
   "scripts": {
-    "prepare": "npm run build",
-    "build": "npm run build:lib && npm run build:docs",
-    "build:lib": "tsc && mjs-entry src/index.ts > lib/index.mjs",
+    "prepare": "npm run build && npm run build:docs && mjs-entry src/index.ts > lib/index.mjs",
+    "build": "tsc --build docs/examples",
     "build:docs": "typedoc",
-    "typecheck": "npm run typecheck:lib && npm run typecheck:docs",
-    "typecheck:lib": "tsc --noEmit",
-    "typecheck:docs": "tsc --build docs/examples",
-    "pretest": "npm run build:lib",
+    "typecheck": "tsc --noEmit",
+    "pretest": "npm run build",
     "test": "ava test/*",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "clean": "git clean -fX docs/build/ lib/ typings/"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "telegraf": "./bin/telegraf"
   },
   "scripts": {
-    "pretest": "npm run typecheck",
     "prepare": "npm run build",
     "build": "npm run build:lib && npm run build:docs",
     "build:lib": "tsc && mjs-entry src/index.ts > lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "prepare": "npm run build && mjs-entry src/index.ts > lib/index.mjs",
     "build": "tsc --build docs/examples",
     "build:docs": "typedoc",
-    "typecheck": "tsc --noEmit",
     "pretest": "npm run build",
     "test": "ava test/*",
     "lint": "eslint --cache .",


### PR DESCRIPTION
# Description

Adds build scripts for convenient building of the library and the docs.

- `prepare`: npm hook that calls the build script both before `npm publish` and after `npm install`
- `typecheck`: checks the types of both lib and docs
- `typecheck:lib`: checks the types of the library
- `typecheck:docs`: checks the types of the docs (examples bots there)
- `build`: builds both lib and docs
- `build:lib`: builds the library
- `build:docs`: builds the docs
- `pretest`: npm hook that builds the lib before `npm test`
- `test`: runs the tests
- `lint`: lints the project
- `clean`: remove generated files