### PR TITLE
Make `ctx.botInfo` required

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -70,7 +70,6 @@ const MessageSubTypesMapping = {
 }
 
 export class Context {
-  public botInfo?: tt.UserFromGetMe
   readonly updateType: tt.UpdateType
   readonly updateSubTypes: ReadonlyArray<typeof MessageSubTypes[number]>
   readonly state: Record<string | symbol, any> = {}
@@ -78,6 +77,7 @@ export class Context {
   constructor(
     readonly update: tt.Update,
     readonly tg: Telegram,
+    public readonly botInfo: tt.UserFromGetMe,
     private readonly options: { channelMode?: boolean; username?: string } = {}
   ) {
     this.updateType = UpdateTypes.find((key) => key in this.update)!

--- a/src/context.ts
+++ b/src/context.ts
@@ -78,7 +78,7 @@ export class Context {
     readonly update: tt.Update,
     readonly tg: Telegram,
     public readonly botInfo: tt.UserFromGetMe,
-    private readonly options: { channelMode?: boolean; username?: string } = {}
+    private readonly options: { channelMode?: boolean } = {}
   ) {
     this.updateType = UpdateTypes.find((key) => key in this.update)!
     // prettier-ignore
@@ -98,7 +98,7 @@ export class Context {
   }
 
   get me() {
-    return this.options.username
+    return this.botInfo?.username
   }
 
   get telegram() {

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -77,7 +77,8 @@ export class Telegraf<
 > extends Composer<TContext> {
   private readonly options: Telegraf.Options<TContext>
   private webhookServer?: http.Server | https.Server
-  private botInfo!: tt.UserFromGetMe
+  /** Set manually to avoid implicit `getMe` call in `launch` or `webhookCallback` */
+  public botInfo?: tt.UserFromGetMe
   public telegram: Telegram
   readonly context: Partial<TContext> = {}
   private readonly polling = {
@@ -126,7 +127,7 @@ export class Telegraf<
   webhookCallback(path = '/', skipBotInfoInitialization = false) {
     return generateCallback(
       path,
-      async (update: tt.Update, res: any) => {
+      async (update: tt.Update, res: http.ServerResponse) => {
         if (!skipBotInfoInitialization) {
           try {
             this.botInfo ??= await this.telegram.getMe()
@@ -180,7 +181,7 @@ export class Telegraf<
 
   async launch(config: Telegraf.LaunchOptions = {}) {
     debug('Connecting to Telegram')
-    this.botInfo = await this.telegram.getMe()
+    this.botInfo ??= await this.telegram.getMe()
     debug(`Launching @${this.botInfo.username}`)
     if (!config.webhook) {
       const { timeout, limit, allowedUpdates, stopCallback } =

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -125,13 +125,11 @@ export class Telegraf<
   }
 
   webhookCallback(path = '/') {
-    let mustFetchBotInfo = !this.botInfo
     let botInfoCall: Promise<void> | undefined
     return generateCallback(
       path,
       async (update: tt.Update, res: http.ServerResponse) => {
-        if (mustFetchBotInfo) {
-          mustFetchBotInfo = false
+        if (!this.botInfo) {
           await (botInfoCall ??= (async () => {
             try {
               this.botInfo ??= await this.telegram.getMe()

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -126,7 +126,7 @@ export class Telegraf<
 
   webhookCallback(path = '/') {
     let mustFetchBotInfo = !this.botInfo
-    let botInfoCall: Promise<unknown> | undefined
+    let botInfoCall: Promise<void> | undefined
     return generateCallback(
       path,
       async (update: tt.Update, res: http.ServerResponse) => {

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -125,20 +125,11 @@ export class Telegraf<
   }
 
   webhookCallback(path = '/') {
-    let botInfoCall: Promise<void> | undefined
+    let botInfoCall: Promise<tt.UserFromGetMe> | undefined
     return generateCallback(
       path,
       async (update: tt.Update, res: http.ServerResponse) => {
-        if (!this.botInfo) {
-          await (botInfoCall ??= (async () => {
-            try {
-              this.botInfo ??= await this.telegram.getMe()
-            } catch (err) {
-              debug('Could not initialize `botInfo`', err)
-              throw err
-            }
-          })())
-        }
+        this.botInfo ??= await (botInfoCall ??= this.telegram.getMe())
         return await this.handleUpdate(update, res)
       },
       debug

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -126,16 +126,19 @@ export class Telegraf<
 
   webhookCallback(path = '/') {
     let mustFetchBotInfo = !this.botInfo
+    let botInfoCall: Promise<unknown> | undefined
     return generateCallback(
       path,
       async (update: tt.Update, res: http.ServerResponse) => {
         if (mustFetchBotInfo) {
           mustFetchBotInfo = false
-          try {
-            this.botInfo ??= await this.telegram.getMe()
-          } catch (err) {
-            debug('Could not initialize bot info', err)
-          }
+          await (botInfoCall ??= (async () => {
+            try {
+              this.botInfo ??= await this.telegram.getMe()
+            } catch (err) {
+              debug('Could not initialize bot info', err)
+            }
+          })())
         }
         return await this.handleUpdate(update, res)
       },

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -136,7 +136,8 @@ export class Telegraf<
             try {
               this.botInfo ??= await this.telegram.getMe()
             } catch (err) {
-              debug('Could not initialize bot info', err)
+              debug('Could not initialize `botInfo`', err)
+              throw err
             }
           })())
         }

--- a/test/composer.js
+++ b/test/composer.js
@@ -496,7 +496,8 @@ test.cb('should handle settings command', (t) => {
 })
 
 test.cb('should handle group command', (t) => {
-  const bot = new Telegraf(null, { username: 'bot' })
+  const bot = new Telegraf(null)
+  bot.botInfo = { username: 'bot' }
   bot.start(() => t.end())
   bot.handleUpdate({ message: { text: '/start@bot', entities: [{ type: 'bot_command', offset: 0, length: 10 }], ...baseGroupMessage } })
 })
@@ -555,14 +556,15 @@ test.cb('should handle short command', (t) => {
 })
 
 test.cb('should handle command in group', (t) => {
-  const bot = new Telegraf('---', { username: 'bot' })
+  const bot = new Telegraf(null)
+  bot.botInfo = { username: 'bot' }
   bot.start(() => t.end())
   bot.handleUpdate({ message: { text: '/start@bot', entities: [{ type: 'bot_command', offset: 0, length: 10 }], chat: { id: 2, type: 'group' } } })
 })
 
 test.cb('should handle command in supergroup', (t) => {
-  const bot = new Telegraf()
-  bot.options.username = 'bot'
+  const bot = new Telegraf(null)
+  bot.botInfo = { username: 'bot' }
   bot.start(() => t.end())
   bot.handleUpdate({ message: { text: '/start@bot', entities: [{ type: 'bot_command', offset: 0, length: 10 }], chat: { id: 2, type: 'supergroup' } } })
 })


### PR DESCRIPTION
# Description

Makes sure that `ctx.botInfo` is always initialized. Makes that property required, too.

Setting `botInfo` directly allows for the feature to be disabled. [Reason](https://github.com/telegraf/telegraf/issues/798#issuecomment-554002376).

Fixes #1072
Impacts #798

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

```bash
npm run build
npm test
npm run lint
```