### PR TITLE
Exclude built docs from linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,7 @@
   "rules": {
     "no-warning-comments": "warn"
   },
-  "ignorePatterns": ["/lib/", "/typings/"],
+  "ignorePatterns": ["/lib/", "/typings/", "/docs/build/"],
   "reportUnusedDisableDirectives": true,
   "plugins": ["ava"]
 }


### PR DESCRIPTION
# Description

Try running `npm run build:docs && npm run lint` to see a flood of linting errors in the built docs.

## Type of change

Config update.

# How Has This Been Tested?

```bash
npm run build:docs
npm run lint
```
