### PR TITLE
Ignore options explicitly set to `undefined`

### DIFF
--- a/src/core/helpers/compact.ts
+++ b/src/core/helpers/compact.ts
@@ -1,0 +1,12 @@
+export function compactOptions<T extends { [key: string]: unknown }>(
+  options?: T
+): T | undefined {
+  if (!options) {
+    return options
+  }
+
+  const keys = Object.keys(options) as Array<keyof T>
+  const compactKeys = keys.filter((key) => options[key] !== undefined)
+  const compactEntries = compactKeys.map((key) => [key, options[key]])
+  return Object.fromEntries(compactEntries)
+}

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 import * as http from 'http'
 import * as https from 'https'
 import * as path from 'path'
+import { compactOptions } from '../helpers/compact'
 import fetch, { RequestInfo, RequestInit } from 'node-fetch'
 import { hasProp, hasPropType } from '../helpers/check'
 import { Opts, Telegram } from '../../telegram-types'
@@ -80,13 +81,6 @@ function includesMedia(payload: Record<string, unknown>) {
             (hasProp(value.media, 'url') && value.media.url))))
     )
   })
-}
-
-function compactOptions<T>(options: T): T {
-  const keys = Object.keys(options) as Array<keyof T>
-  const compactKeys = keys.filter((key) => options[key] !== undefined)
-  const compactEntries = compactKeys.map((key) => [key, options[key]])
-  return Object.fromEntries(compactEntries)
 }
 
 function replacer(_: unknown, value: unknown) {
@@ -314,7 +308,7 @@ class ApiClient {
     this.token = token
     this.options = {
       ...DEFAULT_OPTIONS,
-      ...compactOptions(options ?? {}),
+      ...compactOptions(options),
     }
     if (this.options.apiRoot.startsWith('http://')) {
       this.options.agent = undefined

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -82,6 +82,20 @@ function includesMedia(payload: Record<string, unknown>) {
   })
 }
 
+type ObjectKeys<T> = { [K in keyof T]: T[K] extends {} ? K : never }[keyof T]
+type CompactKeys<T> = Exclude<ObjectKeys<T>, undefined>
+type Compact<T> = Pick<T, CompactKeys<T>>
+function compactUserOptions<T>(options: T): Compact<T> {
+  const compactOptions: Compact<T> = {} as Compact<T>;
+  const optionKeys = Object.keys(options)
+    .filter(key => key !== undefined) as Array<keyof Compact<T>>;
+  for (let key of optionKeys) {
+    const value = options[key];
+    compactOptions[key] = value;
+  }
+  return compactOptions;
+}
+
 function replacer(_: unknown, value: unknown) {
   if (value == null) return undefined
   return value
@@ -307,7 +321,7 @@ class ApiClient {
     this.token = token
     this.options = {
       ...DEFAULT_OPTIONS,
-      ...options,
+      ...compactUserOptions(options ?? {}),
     }
     if (this.options.apiRoot.startsWith('http://')) {
       this.options.agent = undefined

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -82,19 +82,11 @@ function includesMedia(payload: Record<string, unknown>) {
   })
 }
 
-// Types are pretty wrong if applied to a Partial but
-// is passable if applied to an already defined object
-// E.g. compactOptions({ a: number, b?: number })
-// produces Type { a: number }
-type CompactKeys<T> = Exclude<
-  { [K in keyof T]: T[K] extends {} ? K : never }[keyof T],
-  undefined
->
-type Compact<T> = Pick<T, CompactKeys<T>>
-function compactOptions<T>(options: T): Compact<T> {
-  const compactKeys = Object.keys(options).filter(
-    (key) => key !== undefined
-  ) as Array<keyof Compact<T>>
+function compactOptions<T>(options: T): T {
+  const keys = Object.keys(options) as (keyof T)[]
+  const compactKeys = keys.filter(
+    (key) => options[key] !== undefined
+  )
   const compactEntries = compactKeys.map((key) => [key, options[key]])
   return Object.fromEntries(compactEntries)
 }

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -83,10 +83,8 @@ function includesMedia(payload: Record<string, unknown>) {
 }
 
 function compactOptions<T>(options: T): T {
-  const keys = Object.keys(options) as (keyof T)[]
-  const compactKeys = keys.filter(
-    (key) => options[key] !== undefined
-  )
+  const keys = Object.keys(options) as Array<keyof T>
+  const compactKeys = keys.filter((key) => options[key] !== undefined)
   const compactEntries = compactKeys.map((key) => [key, options[key]])
   return Object.fromEntries(compactEntries)
 }

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -86,8 +86,10 @@ function includesMedia(payload: Record<string, unknown>) {
 // is passable if applied to an already defined object
 // E.g. compactOptions({ a: number, b?: number })
 // produces Type { a: number }
-type Keys<T> = { [K in keyof T]: T[K] extends {} ? K : never }[keyof T]
-type CompactKeys<T> = Exclude<Keys<T>, undefined>
+type CompactKeys<T> = Exclude<
+  { [K in keyof T]: T[K] extends {} ? K : never }[keyof T],
+  undefined
+>
 type Compact<T> = Pick<T, CompactKeys<T>>
 function compactOptions<T>(options: T): Compact<T> {
   const compactKeys = Object.keys(options).filter(

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -5,6 +5,7 @@ import ApiClient from './core/network/client'
 import Composer from './composer'
 import Context from './context'
 import crypto from 'crypto'
+import { compactOptions } from './core/helpers/compact'
 import d from 'debug'
 import generateCallback from './core/network/webhook'
 import { promisify } from 'util'
@@ -102,7 +103,7 @@ export class Telegraf<
     // @ts-expect-error
     this.options = {
       ...DEFAULT_OPTIONS,
-      ...options,
+      ...compactOptions(options),
     }
     this.telegram = new Telegram(token, this.options.telegram)
   }


### PR DESCRIPTION
# Description

Add a helper `compactOptions` function that removes all `undefined` values from a plain object's key-value pairs. Apply the `compactOptions` function on the user-provided `options` of type `Partial<ApiClient.Options>` to remove defined keys-values with values set to `undefined`.

When the user explicitly defines `options` with key `apiRoot` set to `undefined`, it will replace the default value of `apiRoot` from `api.telegram.org` to an unusable value. With this change, explicitly setting `apiRoot` to `undefined`, regardless of whether it is intentional or accidental, will be ignored.

Fixes # No issues assigned

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Not Tested

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
