### PR TITLE
Support custom key-value stores in session

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -485,6 +485,15 @@ const session = require('telegraf/session')
 
 const bot = new Telegraf(process.env.BOT_TOKEN)
 bot.use(session())
+// customize session make key algorithm
+//   bot.use(session((ctx) => `${ctx.from.id}:${ctx.chat.id}`))
+//
+// customize session storage backend
+//   bot.use(session(null, {
+//     getItem(name) { ... },
+//     setItem(name, value) { ... },
+//     deleteItem(name) { ... }
+//   }))
 bot.on('text', (ctx) => {
   ctx.session.counter = ctx.session.counter || 0
   ctx.session.counter++

--- a/src/session.ts
+++ b/src/session.ts
@@ -48,8 +48,8 @@ export class MemorySessionStorage<T> implements Storage<T> {
  * see https://npm.im/search?q=telegraf-session
  */
 export function session<SessionData extends object>(
-  storage: Storage<SessionData> = new MemorySessionStorage<SessionData>(),
-  makeKey: StorageKeyFn<Context> = makeDefaultKey
+  makeKey: StorageKeyFn<Context> = makeDefaultKey,
+  storage: Storage<SessionData> = new MemorySessionStorage<SessionData>()
 ): Middleware.ExtFn<Context, { session?: SessionData }> {
   return async (ctx, next) => {
     const key = await makeKey(ctx)

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,12 +17,7 @@ export class MemorySessionStorage<T> implements Storage<T> {
   }
 
   async makeKey(ctx: Context): Promise<string | undefined> {
-    const fromId =
-      ctx.chosenInlineResult?.from.id ??
-      ctx.shippingQuery?.from.id ??
-      ctx.callbackQuery?.from.id ??
-      ctx.from?.id ??
-      null
+    const fromId = ctx.callbackQuery?.from?.id ?? ctx.from?.id ?? null
     const chatId = ctx.callbackQuery?.message?.chat.id ?? ctx.chat?.id ?? null
     if (fromId == null || chatId == null) {
       return undefined

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,29 +1,71 @@
 import { Context } from './context'
 import { Middleware } from './types'
 
-export function session<SessionData extends object>({
-  ttl = Infinity,
-  store = new Map<string, { expires: number; session: SessionData }>(),
-  getSessionKey = (ctx: Context) =>
-    ctx.from && ctx.chat && `${ctx.from.id}:${ctx.chat.id}`,
-} = {}): Middleware.ExtFn<Context, { session?: SessionData }> {
-  const ttlMs = ttl * 1000
+export interface Storage<T> {
+  makeKey: (ctx: Context) => Promise<string | undefined>
+  getItem: (name: string) => Promise<T | undefined>
+  setItem: (name: string, value: T) => Promise<void>
+  deleteItem: (name: string) => Promise<void>
+}
 
+export class MemorySessionStorage<T> implements Storage<T> {
+  private readonly ttl: number
+  private readonly store = new Map<string, { session: T; expires: number }>()
+
+  constructor(ttl = Infinity) {
+    this.ttl = ttl * 1000
+  }
+
+  async makeKey(ctx: Context): Promise<string | undefined> {
+    const fromId =
+      ctx.chosenInlineResult?.from.id ??
+      ctx.shippingQuery?.from.id ??
+      ctx.callbackQuery?.from.id ??
+      ctx.from?.id ??
+      null
+    const chatId = ctx.callbackQuery?.message?.chat.id ?? ctx.chat?.id ?? null
+    if (fromId == null || chatId == null) {
+      return undefined
+    }
+    return `${fromId}:${chatId}`
+  }
+
+  async getItem(name: string): Promise<T | undefined> {
+    const entry = this.store.get(name)
+    if (entry == null) {
+      return undefined
+    } else if (entry.expires < Date.now()) {
+      await this.deleteItem(name)
+      return undefined
+    }
+    return entry.session
+  }
+
+  async setItem(name: string, value: T): Promise<void> {
+    const now = Date.now()
+    this.store.set(name, { session: value, expires: now + this.ttl })
+  }
+
+  async deleteItem(name: string): Promise<void> {
+    this.store.delete(name)
+  }
+}
+
+export function session<SessionData extends object>(
+  storage: Storage<SessionData> = new MemorySessionStorage<SessionData>()
+): Middleware.ExtFn<Context, { session?: SessionData }> {
   return async (ctx, next) => {
-    const key = getSessionKey(ctx)
+    const key = await storage.makeKey(ctx)
     if (key == null) {
       return await next(ctx)
     }
-    const now = Date.now()
-    const entry = store.get(key)
-    const ctx2 = Object.assign(ctx, {
-      session: entry == null || entry.expires < now ? undefined : entry.session,
-    })
+    const entry = await storage.getItem(key)
+    const ctx2 = Object.assign(ctx, { session: entry })
     await next(ctx2)
     if (ctx2.session == null) {
-      store.delete(key)
+      await storage.deleteItem(key)
     } else {
-      store.set(key, { session: ctx2.session, expires: now + ttlMs })
+      await storage.setItem(key, ctx2.session)
     }
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,35 +11,6 @@ export interface Storage<T> {
   deleteItem: (name: string) => Promise<void>
 }
 
-export class MemorySessionStorage<T> implements Storage<T> {
-  private readonly ttl: number
-  private readonly store = new Map<string, { session: T; expires: number }>()
-
-  constructor(ttl = Infinity) {
-    this.ttl = ttl * 1000
-  }
-
-  async getItem(name: string): Promise<T | undefined> {
-    const entry = this.store.get(name)
-    if (entry == null) {
-      return undefined
-    } else if (entry.expires < Date.now()) {
-      await this.deleteItem(name)
-      return undefined
-    }
-    return entry.session
-  }
-
-  async setItem(name: string, value: T): Promise<void> {
-    const now = Date.now()
-    this.store.set(name, { session: value, expires: now + this.ttl })
-  }
-
-  async deleteItem(name: string): Promise<void> {
-    this.store.delete(name)
-  }
-}
-
 /**
  * session middleware
  *
@@ -74,4 +45,33 @@ async function makeDefaultKey(ctx: Context): Promise<string | undefined> {
     return undefined
   }
   return `${fromId}:${chatId}`
+}
+
+export class MemorySessionStorage<T> implements Storage<T> {
+  private readonly ttl: number
+  private readonly store = new Map<string, { session: T; expires: number }>()
+
+  constructor(ttl = Infinity) {
+    this.ttl = ttl * 1000
+  }
+
+  async getItem(name: string): Promise<T | undefined> {
+    const entry = this.store.get(name)
+    if (entry == null) {
+      return undefined
+    } else if (entry.expires < Date.now()) {
+      await this.deleteItem(name)
+      return undefined
+    }
+    return entry.session
+  }
+
+  async setItem(name: string, value: T): Promise<void> {
+    const now = Date.now()
+    this.store.set(name, { session: value, expires: now + this.ttl })
+  }
+
+  async deleteItem(name: string): Promise<void> {
+    this.store.delete(name)
+  }
 }


### PR DESCRIPTION
# Description

Allow use external (asynchronous) key-value database. (e.q: level db / mongodb / etc)
Read/Write session data on external persistent database service.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples or any documentation update)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Node.js Version:
* Operating System:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
