### PR TITLE
Local session - Avoid overriding the middleware's result with an empty object

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -31,12 +31,13 @@ export function session<SessionData extends object>(
     }
     const entry = await storage.getItem(key)
     const ctx2 = Object.assign(ctx, { session: entry })
-    await next(ctx2)
+    const nextResult = await next(ctx2)
     if (ctx2.session == null) {
       await storage.deleteItem(key)
     } else {
       await storage.setItem(key, ctx2.session)
     }
+    return nextResult
   }
 }
 


### PR DESCRIPTION
# Description

1. Summary of the change: small change of the async call of the next middleware in the local session middleware. The next/inner middleware might want to return some data, therefore, forward a potential resolution data.
2. Motivation: In the previous release, it was worse, as it returned the result of `Map#set` call. Anyway, it's maybe the best, but when I tried testing my code, in some cases, it seemed good to test the promise resolution data.

3. Fixes issue: _none created, none related found_

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
  - _Kind of_


# How Has This Been Tested?

Did run the AVA tests already present in the project. Can't imagine a world where I broke anything with this change.

**Test Configuration**:
* Node.js Version: _v15.2.1_
* Operating System: _macOS Big Sur, version 11.0.1_

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
  - Not sure which warnings you are referring to.
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Should I add a test for this pretty special use case?
- [x] New and existing unit tests pass locally with my changes


PS. Can't wait to get my hands on the next release. Nice work! 👍🏼 