### PR TITLE
Remove `silent` flag from `SceneContextScene::enter`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2456,7 +2456,7 @@ Scenes related context props and functions:
 ```js
 bot.on('message', (ctx) => {
   ctx.scene.state                                    // Current scene state (persistent)
-  ctx.scene.enter(sceneId, [defaultState, silent])   // Enter scene
+  ctx.scene.enter(sceneId, [defaultState])           // Enter scene
   ctx.scene.reenter()                                // Reenter current scene
   ctx.scene.leave()                                  // Leave scene
 })

--- a/src/scenes/context.ts
+++ b/src/scenes/context.ts
@@ -80,25 +80,19 @@ class SceneContextScene<C extends SceneContext> {
     this.ctx.session.__scenes = {}
   }
 
-  async enter(
-    sceneId: string,
-    initialState: object = {},
-    silent: boolean = false
-  ) {
+  async enter(sceneId: string, initialState = {}) {
     if (!this.scenes.has(sceneId)) {
       throw new Error(`Can't find scene: ${sceneId}`)
     }
-    if (!silent) {
-      await this.leave()
-    }
-    debug('Enter scene', sceneId, initialState, silent)
+    await this.leave()
+    debug('Entering scene', sceneId, initialState)
     this.session.current = sceneId
     this.state = initialState
     const ttl = this.current?.ttl ?? this.options.ttl
     if (ttl !== undefined) {
       this.session.expires = now() + ttl
     }
-    if (this.current === undefined || silent) {
+    if (this.current === undefined) {
       return
     }
     const handler =
@@ -116,7 +110,7 @@ class SceneContextScene<C extends SceneContext> {
   }
 
   async leave() {
-    debug('Leave scene')
+    debug('Leaving scene')
     if (this.current === undefined) {
       return
     }


### PR DESCRIPTION
# Description

There's no point to have enter and leave hooks if caller can skip calling them anytime.

See https://github.com/telegraf/telegraf/issues/1241#issuecomment-747503292

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
