### PR TITLE
Rewrite update handling

### DIFF
--- a/src/core/network/polling.ts
+++ b/src/core/network/polling.ts
@@ -18,7 +18,8 @@ export class Polling {
   public limit: number | undefined
   constructor(
     private readonly telegram: ApiClient,
-    private readonly allowedUpdates: readonly tt.UpdateType[]
+    private readonly allowedUpdates: readonly tt.UpdateType[],
+    private readonly timeout: number
   ) {}
 
   private async *[Symbol.asyncIterator]() {
@@ -28,7 +29,7 @@ export class Polling {
         const updates = await this.telegram.callApi(
           'getUpdates',
           {
-            timeout: 50,
+            timeout: this.timeout,
             offset: this.offset,
             allowed_updates: this.allowedUpdates,
             limit: this.limit,

--- a/src/core/network/polling.ts
+++ b/src/core/network/polling.ts
@@ -15,6 +15,7 @@ export class Polling {
   private readonly abortController = new AbortController()
   private skipOffsetSync = false
   private offset = 0
+  public limit: number | undefined
   constructor(
     private readonly telegram: ApiClient,
     private readonly allowedUpdates: readonly tt.UpdateType[]
@@ -30,6 +31,7 @@ export class Polling {
             timeout: 50,
             offset: this.offset,
             allowed_updates: this.allowedUpdates,
+            limit: this.limit,
           },
           this.abortController
         )

--- a/src/core/network/webhook.ts
+++ b/src/core/network/webhook.ts
@@ -36,7 +36,7 @@ export default function (
       }
       updateHandler(update, res)
         .then(() => {
-          if (!res.finished) {
+          if (!res.writableEnded) {
             res.end()
           }
         })

--- a/src/core/processing/queue.ts
+++ b/src/core/processing/queue.ts
@@ -1,0 +1,130 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+interface Drift<E> {
+  prev: Drift<E> | null
+  next: Drift<E> | null
+
+  task: Promise<void>
+
+  date: number
+  elem: E
+}
+
+export class DecayingDeque<E> {
+  private length: number = 0
+  private head: Drift<E> | null = null
+  private tail: Drift<E> | null = null
+
+  private readonly concurrency: number
+  private timer: NodeJS.Timeout | undefined
+  private subscribers: Array<(capacity: number) => void> = []
+
+  /**
+   * Creates a new decaying queue, confer
+   * @param handlerTimeout max period of time for a task
+   * @param worker task generator
+   * @param concurrency `add` will return only after the number of pending tasks fell below `concurrency`. `false` means `1`, `true` means `Infinity`, numbers below `1` mean `1`
+   * @param catchError error handler
+   * @param catchTimeout timeout handler
+   */
+  constructor(
+    private readonly handlerTimeout: number,
+    private readonly worker: (t: E) => Promise<void>,
+    concurrency: boolean | number,
+    private readonly catchError: (err: unknown, elem: E) => Promise<void>,
+    private readonly catchTimeout: (t: E, task: Promise<void>) => void
+  ) {
+    if (concurrency === false) this.concurrency = 1
+    else if (concurrency === true) this.concurrency = Infinity
+    else this.concurrency = concurrency < 1 ? 1 : concurrency
+  }
+
+  /**
+   * Adds the provided elements to the queue and starts tasks for all of them
+   * immediately. Returns a `Promise` that resolves with `concurrency - length`
+   * once this value becomes positive.
+   * @param elems elements to be added
+   * @returns `capacity - length` inside a `Promise`
+   */
+  add(elems: E[]): Promise<number> {
+    const len = elems.length
+    const capacity = this.concurrency - (this.length += len)
+
+    if (len > 0) {
+      let i = 0
+      const now = Date.now()
+      if (this.head === null) {
+        this.head = this.tail = this.toDrift(elems[i++]!, now)
+        this.startTimer()
+      }
+
+      let prev = this.tail!
+      while (i < len) {
+        const node = this.toDrift(elems[i++]!, now)
+        prev.next = node
+        node.prev = prev
+        prev = node
+      }
+      this.tail = prev
+    }
+
+    return capacity > 0
+      ? Promise.resolve(capacity)
+      : new Promise((resolve) => this.subscribers.push(resolve))
+  }
+
+  private decay(node: Drift<E>): void {
+    if (node.date !== node.next?.date)
+      if (this.head === node) {
+        if (this.timer !== undefined) clearTimeout(this.timer)
+        if (node.next === null) this.timer = undefined
+        else this.startTimer(node.next.date + this.handlerTimeout - Date.now())
+      }
+    this.remove(node)
+  }
+
+  private remove(node: Drift<E>): void {
+    if (this.head === node) this.head = node.next
+    else node.prev!.next = node.next
+    if (this.tail === node) this.tail = node.prev
+    else node.next!.prev = node.prev
+
+    node.date = -1
+    const capacity = this.concurrency - --this.length
+    if (capacity > 0) {
+      this.subscribers.forEach((resolve) => resolve(capacity))
+      this.subscribers = []
+    }
+  }
+
+  private toDrift(elem: E, date: number): Drift<E> {
+    const node: Drift<E> = {
+      prev: null,
+      task: this.worker(elem)
+        .catch(async (err) => {
+          if (node.date > 0) await this.catchError(err, elem)
+          else throw err
+        })
+        .finally(() => {
+          if (node.date > 0) this.decay(node)
+        }),
+      next: null,
+      date,
+      elem,
+    }
+    return node
+  }
+
+  private startTimer(ms = this.handlerTimeout): void {
+    if (ms < 1) setImmediate(() => this.timeout())
+    else this.timer = setTimeout(() => this.timeout(), ms).unref()
+  }
+
+  private timeout(): void {
+    while (this.head!.date === this.head!.next?.date) {
+      this.catchTimeout(this.head!.elem, this.head!.task)
+      this.remove(this.head!)
+    }
+    this.catchTimeout(this.head!.elem, this.head!.task)
+    this.decay(this.head!)
+  }
+}

--- a/src/core/processing/queue.ts
+++ b/src/core/processing/queue.ts
@@ -1,30 +1,111 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+/**
+ * A drift is an element in a doubly linked list, and it stores a task. A task
+ * is represented as a Promise. Drifts remove themselves from the queue (they
+ * _decay_) after their task completes or exceeds the timeout. The timeout is
+ * the maximum time that drifts are allowed to be contained in the queue.
+ *
+ * Drifts are appended to the tail of the queue and _drift_ towards the head as
+ * older elements are removed, hence the name.
+ *
+ * The task of every drift is created by a worker function that operates based
+ * on a source element. A drift keeps a reference to that source element. In
+ * case of a timeout, the timeout handlers will be supplied with the source
+ * element because it is interesting to know for which source elements the
+ * worker function produced a promise that timed out.
+ *
+ * A drift also stores the date at which it was added to the queue.
+ *
+ * In the context of `telegraf`, each middleware invocation corresponds to a
+ * task in a drift. Drifts are used to manage concurrent middleware execution.
+ */
 interface Drift<E> {
+  /** Previous drift in the queue. `null` iff this drift is the head element. */
   prev: Drift<E> | null
+  /** Next drift in the queue. `null` iff this drift is the tail element. */
   next: Drift<E> | null
 
+  /**
+   * Task of the drift. Contains logic that removes this drift from the queue as
+   * soon as the task completes by itself (either resolves or rejects).
+   */
   task: Promise<void>
 
+  /**
+   * Timestamp (milliseconds since The Epoch) when this drift was added. This
+   * may be inspected when starting a new timer that might purge this drift upon
+   * timeout.
+   *
+   * The timestamp will be set to `-1` when the drift is removed from the queue,
+   * in other words, checking `date > 0` serves as a containment test.
+   */
   date: number
+  /** Reference to the source element that was used to start the task */
   elem: E
 }
 
+/**
+ * A _decaying deque_ is a special kind of doubly linked list that serves as a
+ * queue for a special kind of nodes, called _drifts_.
+ *
+ * A decaying deque has a worker function that spawns a task for each element
+ * that is added to the queue. This task then gets wrapped into a drift. The
+ * drifts are then the actual elements in the queue.
+ *
+ * In addition, the decaying deque runs a timer that purges old elements from
+ * the queue. This period of time is determined by the `handlerTimeout`.
+ *
+ * When a task completes or exceeds its timeout, the corresponding drift is
+ * removed from the queue. As a result, only drifts with pending tasks are
+ * contained in the queue at all times.
+ *
+ * When a tasks completes with failure (`reject`s or exceeds the timeout), the
+ * respective handler (`catchError` or `catchTimeout`) is called.
+ *
+ * The decaying deque has its name from the observation that new elements are
+ * appended to the tail, and the old elements are removed at arbitrary positions
+ * in the queue whenever a task completes, hence, the queue seems to _decay_.
+ */
 export class DecayingDeque<E> {
+  /**
+   * Number of drifts in the queue. Equivalent to the number of currently
+   * pending tasks.
+   */
   private length: number = 0
+  /** Head element (oldest), `null` iff the queue is empty */
   private head: Drift<E> | null = null
+  /** Tail element (newest), `null` iff the queue is empty */
   private tail: Drift<E> | null = null
 
+  /**
+   * Number of currently pending tasks that we strive for (`add` calls will
+   * resolve only after the number of pending tasks falls below this value.
+   *
+   * In the context of `telegraf`, it is possible to `await` calls to `add` to
+   * determine when to fetch more updates.
+   */
   private readonly concurrency: number
+  /**
+   * Timer that waits for the head element to time out, will be rescheduled
+   * whenever the head element changes. It is `undefined` iff queue is empty.
+   */
   private timer: NodeJS.Timeout | undefined
+  /**
+   * List of subscribers that wait for the queue to be empty. All functions in
+   * this array will be called as soon as new capacity is available, i.e. the
+   * number of pending tasks falls below `concurrency`.
+   */
   private subscribers: Array<(capacity: number) => void> = []
 
   /**
-   * Creates a new decaying queue, confer
+   * Creates a new decaying queue with the given parameters.
+   *
    * @param handlerTimeout max period of time for a task
    * @param worker task generator
    * @param concurrency `add` will return only after the number of pending tasks fell below `concurrency`. `false` means `1`, `true` means `Infinity`, numbers below `1` mean `1`
-   * @param catchError error handler
-   * @param catchTimeout timeout handler
+   * @param catchError error handler, receives the error and the source element
+   * @param catchTimeout timeout handler, receives the source element and the promise of the task
    */
   constructor(
     private readonly handlerTimeout: number,
@@ -52,14 +133,19 @@ export class DecayingDeque<E> {
     if (len > 0) {
       let i = 0
       const now = Date.now()
+
+      // emptyness check
       if (this.head === null) {
         this.head = this.tail = this.toDrift(elems[i++]!, now)
+        // start timer because head element changed
         this.startTimer()
       }
 
       let prev = this.tail!
       while (i < len) {
+        // create drift from source element
         const node = this.toDrift(elems[i++]!, now)
+        // link it to previous element (append operation)
         prev.next = node
         node.prev = prev
         prev = node
@@ -67,28 +153,50 @@ export class DecayingDeque<E> {
       this.tail = prev
     }
 
+    // Resolve immediately if there is free space, otherwise postpone this
     return capacity > 0
       ? Promise.resolve(capacity)
       : new Promise((resolve) => this.subscribers.push(resolve))
   }
 
+  /**
+   * Called when a node completed its lifecycle and should be removed from the
+   * queue. Effectively wraps the `remove` call and takes care of the timer.
+   *
+   * @param node drift to decay
+   */
   private decay(node: Drift<E>): void {
-    if (node.date !== node.next?.date)
-      if (this.head === node) {
-        if (this.timer !== undefined) clearTimeout(this.timer)
-        if (node.next === null) this.timer = undefined
-        else this.startTimer(node.next.date + this.handlerTimeout - Date.now())
-      }
+    // We only need to restart the timer if we decay the head element of the
+    // queue, however, if the next element has the same date as `node`, we can
+    // skip this step, too.
+    if (this.head === node && node.date !== node.next?.date) {
+      // Clear previous timeout
+      if (this.timer !== undefined) clearTimeout(this.timer)
+      // Emptyness check (do not start if queue is now empty)
+      if (node.next === null) this.timer = undefined
+      // Reschedule timer for the next node's timeout
+      else this.startTimer(node.next.date + this.handlerTimeout - Date.now())
+    }
     this.remove(node)
   }
 
+  /**
+   * Removes an element from the queue. Calls subscribers if there is capacity
+   * after performing this operation.
+   *
+   * @param node drift to remove
+   */
   private remove(node: Drift<E>): void {
+    // Connecting the links of `prev` and `next` removes `node`
     if (this.head === node) this.head = node.next
     else node.prev!.next = node.next
     if (this.tail === node) this.tail = node.prev
     else node.next!.prev = node.prev
 
+    // Mark this drift as no longer contained
     node.date = -1
+
+    // Notify subscribers if there is capacity by now
     const capacity = this.concurrency - --this.length
     if (capacity > 0) {
       this.subscribers.forEach((resolve) => resolve(capacity))
@@ -96,15 +204,27 @@ export class DecayingDeque<E> {
     }
   }
 
+  /**
+   * Takes a source element and starts the task for it by calling the worker
+   * function. Then wraps this task into a drift. Also makes sure that the drift
+   * removes itself from the queue once it completes, and that the error handler
+   * is invoked if it fails (rejects).
+   *
+   * @param elem source element
+   * @param date date when this drift is created
+   */
   private toDrift(elem: E, date: number): Drift<E> {
     const node: Drift<E> = {
       prev: null,
       task: this.worker(elem)
         .catch(async (err) => {
+          // Rethrow iff the drift was removed by a timeout before
           if (node.date > 0) await this.catchError(err, elem)
           else throw err
         })
         .finally(() => {
+          // Decay the node once the task completes (unless the drift was
+          // removed due to a timeout before)
           if (node.date > 0) this.decay(node)
         }),
       next: null,
@@ -114,15 +234,29 @@ export class DecayingDeque<E> {
     return node
   }
 
+  /**
+   * Starts a timer that fires off a timeout after the given period of time.
+   *
+   * @param ms number of milliseconds to wait before the timeout kicks in
+   */
   private startTimer(ms = this.handlerTimeout): void {
     if (ms < 1) setImmediate(() => this.timeout())
     else this.timer = setTimeout(() => this.timeout(), ms).unref()
   }
 
+  /**
+   * Performs a timeout event. This removes the head element as well as all
+   * subsequent drifts with the same date (added in the same millisecond).
+   *
+   * The timeout handler is called in sequence for every removed drift.
+   */
   private timeout(): void {
+    // Rare cases of the event ordering might fire a timeout even though the
+    // head element has just decayed.
     if (this.head === null) return
     while (this.head.date === this.head.next?.date) {
       this.catchTimeout(this.head.elem, this.head.task)
+      // No need to restart timer here, we'll modify head again anyway
       this.remove(this.head)
     }
     this.catchTimeout(this.head.elem, this.head.task)

--- a/src/core/processing/queue.ts
+++ b/src/core/processing/queue.ts
@@ -120,11 +120,12 @@ export class DecayingDeque<E> {
   }
 
   private timeout(): void {
-    while (this.head!.date === this.head!.next?.date) {
-      this.catchTimeout(this.head!.elem, this.head!.task)
-      this.remove(this.head!)
+    if (this.head === null) return
+    while (this.head.date === this.head.next?.date) {
+      this.catchTimeout(this.head.elem, this.head.task)
+      this.remove(this.head)
     }
-    this.catchTimeout(this.head!.elem, this.head!.task)
-    this.decay(this.head!)
+    this.catchTimeout(this.head.elem, this.head.task)
+    this.decay(this.head)
   }
 }

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -262,7 +262,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
   }
 
   async handleUpdate(update: tt.Update, webhookResponse?: http.ServerResponse) {
-    await this.handleUpdates([update], webhookResponse)
+    return await this.handleUpdates([update], webhookResponse)
   }
 
   private botInfoCall?: Promise<tt.UserFromGetMe>

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -8,6 +8,7 @@ import { compactOptions } from './core/helpers/compact'
 import Composer from './composer'
 import Context from './context'
 import d from 'debug'
+import { DecayingDeque } from './core/processing/queue'
 import generateCallback from './core/network/webhook'
 import { Polling } from './core/network/polling'
 import Telegram from './telegram'
@@ -25,7 +26,6 @@ function always<T>(x: T) {
   return () => x
 }
 const anoop = always(Promise.resolve())
-const wait = util.promisify(setTimeout)
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Telegraf {
@@ -38,9 +38,39 @@ namespace Telegraf {
   }
 
   export interface LaunchOptions {
-    // FIXME: not honored by webhook
     /** List the types of updates you want your bot to receive */
     allowedUpdates?: tt.UpdateType[]
+    /**
+     * **In long polling mode,** when your bot receives one or more updates,
+     * `telegraf` calls the middleware stack and waits for it to complete before
+     * calling `getUpdates` again. This is important: calling `getUpdates`
+     * [confirms the previously received updates to Telegram via the `offset`
+     * parameter](https://core.telegram.org/bots/api#getupdates), but if your
+     * middleware crashes, you may want to request them again, which would
+     * become impossible then.
+     *
+     * The `concurrency` flag (default: `false`) allows you to adjust this
+     * behavior. It determines the maximum number of updates your bot may
+     * already be processing concurrently before making the next `getUpdates`
+     * request. The higher the number, the earlier `telegraf` will make the next
+     * request. **Caution:** setting this value to anything greater than `1` may
+     * cause your bot to miss updates if it crashes!
+     *
+     * **In webhook mode,** it is possible to receive old updates again while
+     * new ones have already been processed, so this is not an issue. The flag
+     * behaves exactly the same way, but its default value is `true`. If you set
+     * it to a lower value, `telegraf` will simply not answer the HTTP requests
+     * until enough of your middleware completed.
+     *
+     * `false` is an alias for `1`. `true` is an alias for `Infinity`. Values
+     * below `1` will be interpreted as `1`.
+     */
+    concurrency?: boolean | number
+    /** Configuration options for when the bot is run via long polling */
+    polling?: {
+      /** Determines the timout of the `getUpdates` calls */
+      timeout?: number
+    }
     /** Configuration options for when the bot is run via webhooks */
     webhook?: {
       /** Public domain for webhook. If domain is not specified, hookPath should contain a domain name as well (not only path component). */
@@ -60,6 +90,11 @@ namespace Telegraf {
   }
 }
 
+interface Task<C extends Context> {
+  ctx: C
+  webhookResponse?: http.ServerResponse
+}
+
 export class Telegraf<C extends Context = Context> extends Composer<C> {
   private readonly options: Telegraf.Options<C>
   private webhookServer?: http.Server | https.Server
@@ -68,6 +103,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
   public botInfo?: tt.UserFromGetMe
   public telegram: Telegram
   readonly context: Partial<C> = {}
+  private updateQueue: DecayingDeque<Task<C>> | undefined
 
   private handleError = async (err: unknown, ctx: C): Promise<void> => {
     // set exit code to emulate `warn-with-error-code` behavior of
@@ -75,6 +111,20 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     // to prevent a clean exit despite an error being thrown
     process.exitCode = 1
     throw err
+  }
+
+  private handleTimeout = (ctx: C, middleware: Promise<void>): void => {
+    middleware.finally(() =>
+      debug(
+        'Middleware completed after timeout for update',
+        ctx.update.update_id
+      )
+    )
+    // set exit code to emulate `warn-with-error-code` behavior of
+    // https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+    // to prevent a clean exit despite an error being thrown
+    process.exitCode = 1
+    throw new Error(`Timeout in middleware for update ${ctx.update.update_id}`)
   }
 
   constructor(token: string, options?: Partial<Telegraf.Options<C>>) {
@@ -104,20 +154,28 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     return this
   }
 
+  catchTimeout(handler: (ctx: C, middleware: Promise<void>) => void) {
+    this.handleTimeout = handler
+    return this
+  }
+
   webhookCallback(path = '/') {
     return generateCallback(
       path,
-      (update: tt.Update, res: http.ServerResponse) =>
-        this.handleUpdate(update, res),
+      async (update: tt.Update, res: http.ServerResponse) => {
+        await this.handleUpdates([update], res)
+      },
       debug
     )
   }
 
   private startPolling(allowedUpdates: tt.UpdateType[] = []) {
-    this.polling = new Polling(this.telegram, allowedUpdates)
+    const polling = (this.polling = new Polling(this.telegram, allowedUpdates))
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.polling.loop(async (updates) => {
-      await this.handleUpdates(updates)
+    polling.loop(async (updates) => {
+      const capacity = await this.handleUpdates(updates)
+      // request at least 10 updates, or undefined (=100) if unknown
+      polling.limit = capacity === undefined || capacity > 10 ? capacity : 10
     })
   }
 
@@ -142,7 +200,19 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     return this
   }
 
+  initializeQueue(concurrency: boolean | number) {
+    this.updateQueue ??= new DecayingDeque(
+      this.options.handlerTimeout,
+      (t: Task<C>) => this.invokeMiddleware(t),
+      concurrency,
+      (err: unknown, t: Task<C>) => this.handleError(err, t.ctx),
+      (t: Task<C>, p: Promise<void>) => this.handleTimeout(t.ctx, p)
+    )
+  }
+
   async launch(config: Telegraf.LaunchOptions = {}) {
+    this.initializeQueue(config.concurrency ?? config.webhook !== undefined)
+
     debug('Connecting to Telegram')
     this.botInfo ??= await this.telegram.getMe()
     debug(`Launching @${this.botInfo.username}`)
@@ -171,7 +241,9 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
       debug('Bot started with webhook')
       return
     }
-    await this.telegram.setWebhook(`https://${domain}${hookPath}`)
+    await this.telegram.setWebhook(`https://${domain}${hookPath}`, {
+      allowed_updates: config.allowedUpdates,
+    })
     debug(`Bot started with webhook @ https://${domain}`)
   }
 
@@ -185,40 +257,44 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     this.polling?.stop()
   }
 
-  private handleUpdates(updates: readonly tt.Update[]) {
-    if (!Array.isArray(updates)) {
-      throw new TypeError(util.format('Updates must be an array, got', updates))
-    }
-    // prettier-ignore
-    const processAll = Promise.all(updates.map((update) => this.handleUpdate(update)))
-    if (this.options.handlerTimeout === Infinity) {
-      return processAll
-    }
-    return Promise.race([processAll, wait(this.options.handlerTimeout)])
+  async handleUpdate(update: tt.Update, webhookResponse?: http.ServerResponse) {
+    await this.handleUpdates([update], webhookResponse)
   }
 
   private botInfoCall?: Promise<tt.UserFromGetMe>
-  async handleUpdate(update: tt.Update, webhookResponse?: http.ServerResponse) {
-    debug('Processing update', update.update_id)
-    this.botInfo ??=
+  private async handleUpdates(
+    updates: readonly tt.Update[],
+    webhookResponse?: http.ServerResponse
+  ) {
+    if (!Array.isArray(updates)) {
+      throw new TypeError(util.format('Updates must be an array, got', updates))
+    }
+    const botInfo = (this.botInfo ??=
       (debug(
-        'Update',
-        update.update_id,
-        'is waiting for `botInfo` to be initialized'
+        'Updates are waiting for `botInfo` to be initialized:',
+        ...updates.map((u) => u.update_id)
       ),
-      await (this.botInfoCall ??= this.telegram.getMe()))
-    const tg = new Telegram(this.token, this.telegram.options, webhookResponse)
-    const TelegrafContext = this.options.contextType
-    const ctx = new TelegrafContext(update, tg, this.botInfo)
-    Object.assign(ctx, this.context)
+      await (this.botInfoCall ??= this.telegram.getMe())))
+
+    const tasks: Array<Task<C>> = updates.map((update) => {
+      const tg = new Telegram(
+        this.token,
+        this.telegram.options,
+        webhookResponse
+      )
+      const TelegrafContext = this.options.contextType
+      const ctx = new TelegrafContext(update, tg, botInfo)
+      Object.assign(ctx, this.context)
+      return { ctx, webhookResponse }
+    })
+    return await this.updateQueue?.add(tasks)
+  }
+
+  private async invokeMiddleware(t: Task<C>): Promise<void> {
     try {
-      await this.middleware()(ctx, anoop)
-    } catch (err) {
-      return await this.handleError(err, ctx)
+      await this.middleware()(t.ctx, anoop)
     } finally {
-      if (webhookResponse !== undefined && !webhookResponse.writableEnded) {
-        webhookResponse.end()
-      }
+      if (t.webhookResponse?.writableEnded === false) t.webhookResponse?.end()
     }
   }
 }

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -169,8 +169,12 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     )
   }
 
-  private startPolling(allowedUpdates: tt.UpdateType[] = []) {
-    const polling = (this.polling = new Polling(this.telegram, allowedUpdates))
+  private startPolling(allowedUpdates: tt.UpdateType[] = [], timeout = 50) {
+    const polling = (this.polling = new Polling(
+      this.telegram,
+      allowedUpdates,
+      timeout
+    ))
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     polling.loop(async (updates) => {
       const capacity = await this.handleUpdates(updates)
@@ -218,7 +222,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     debug(`Launching @${this.botInfo.username}`)
     if (config.webhook === undefined) {
       await this.telegram.deleteWebhook()
-      this.startPolling(config.allowedUpdates)
+      this.startPolling(config.allowedUpdates, config.polling?.timeout)
       debug('Bot started with long polling')
       return
     }

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -204,7 +204,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     return this
   }
 
-  initializeQueue(concurrency: boolean | number) {
+  private initializeQueue(concurrency: boolean | number) {
     this.updateQueue ??= new DecayingDeque(
       this.options.handlerTimeout,
       (t: Task<C>) => this.invokeMiddleware(t),

--- a/test/composer.js
+++ b/test/composer.js
@@ -4,6 +4,7 @@ const { Composer, Telegraf } = require('../')
 function createBot (...args) {
   const bot = new Telegraf(...args)
   bot.botInfo = { id: 8, is_bot: true, username: 'bot', first_name: 'Bot' }
+  bot.initializeQueue(false)
   return bot
 }
 

--- a/test/queue.js
+++ b/test/queue.js
@@ -1,0 +1,161 @@
+const test = require('ava')
+const { DecayingDeque } = require('../lib/core/processing/queue')
+
+test.cb('should process a single update', (t) => {
+  let res = ''
+  const q = new DecayingDeque(1000, v => Promise.resolve(res += v), false, () => t.fail(), () => t.fail())
+  q.add(['a']).then(() => t.end(res !== 'a'))
+})
+
+test.cb('should process two updates in order', (t) => {
+  let res = ''
+  const q = new DecayingDeque(1000, v => Promise.resolve(res += v), false, () => t.fail(), () => t.fail())
+  q.add(['a', 'b']).then(() => t.end(res !== 'ab'))
+})
+
+test.cb('should process updates from different calls', (t) => {
+  let res = ''
+  const q = new DecayingDeque(1000, v => Promise.resolve(res += v), false, () => t.fail(), () => t.fail())
+  q.add(['a']).then(() => q.add(['b'])).then(() => t.end(res !== 'ab'))
+})
+
+test.cb('should process delayed updates from different calls', (t) => {
+  let res = ''
+  const q = new DecayingDeque(1000, v => Promise.resolve(res += v), false, () => t.fail(), () => t.fail())
+  q.add(['a']).then(() => setTimeout(() => q.add(['b']).then(() => t.end(res !== 'ab')), 10))
+})
+
+test.cb('should catch errors', (t) => {
+  const q = new DecayingDeque(1000, v => Promise.reject(v), false, (err, elem) => t.end(err !== 'a' || elem !== 'a'), () => t.fail())
+  q.add(['a'])
+})
+
+test.cb('should catch multiple errors', (t) => {
+  let res = ''
+  const q = new DecayingDeque(1000, v => Promise.reject(v), false, (err, elem) => {
+    if ((err !== 'a' && err !== 'b') || (elem !== 'a' && elem !== 'b')) t.fail()
+    res += err
+    if (res === 'ab') t.end()
+  }, () => t.fail())
+  q.add(['a', 'b'])
+})
+
+test.cb('should catch timeouts', (t) => {
+  const promise = new Promise(() => { })
+  const q = new DecayingDeque(10, () => promise, false, () => t.fail(), e => t.end(e !== 'a'))
+  q.add(['a'])
+})
+
+test.cb('should catch multiple timeouts', (t) => {
+  const promise = new Promise(() => { })
+  let res = ''
+  const q = new DecayingDeque(10, () => promise, false, () => t.fail(), e => {
+    if (e !== 'a' && e !== 'b') t.fail()
+    res += e
+    if (res === 'ab') t.end()
+  })
+  q.add(['a', 'b'])
+})
+
+function patternTest (t, pattern, expected = pattern) {
+  // `res` collects the results of promises that resolve, reject, or time out,
+  // and these events have to happen in the correct order,
+  // otherwise `res` will be built up the wrong way from the given update pattern
+  let res = ''
+  const q = new DecayingDeque(20, c => {
+    if (c.match(/[a-z]/)) { // value
+      return new Promise((resolve) =>
+        setImmediate(() => {
+          res += c
+          resolve(c)
+        }))
+    } else if (c.match(/[0-9]/)) { // error
+      return new Promise((resolve, reject) =>
+        setImmediate(() => {
+          reject(c)
+        }))
+    } else { // timeout
+      return new Promise(() => { })
+    }
+  }, false, v => (res += v), v => (res += v))
+  q.add([...pattern]).then(() => t.end(res !== expected))
+}
+
+test.cb('should handle simple update patterns', (t) => patternTest(t, 'a'))
+test.cb('should handle long value update patterns', (t) => patternTest(t, 'xxxxxxxxxx'))
+test.cb('should handle long error update patterns', (t) => patternTest(t, '9999999999'))
+test.cb('should handle long timeout update patterns', (t) => patternTest(t, '..........'))
+test.cb('should handle combined update patterns', (t) => patternTest(t, 'x9.'))
+test.cb('should handle mixed update patterns', (t) => patternTest(t, 'a9.b,', 'a9b.,'))
+test.cb('should handle complex update patterns', (t) => patternTest(t,
+  'jadf.)(r45%4hj2h()$..x)=1kj5kfgg}]3567',
+  'jadfr454hj2hx1kj5kfgg3567.)(%()$..)=}]'))
+
+test.cb('should return the correct capacity value for a single element', (t) => {
+  const q = new DecayingDeque(1000, () => Promise.resolve(), 12, () => t.fail(), () => t.fail())
+  q.add(['a']).then(c => t.end(c !== 11))
+})
+
+test.cb('should return the correct capacity value for multiple elements', (t) => {
+  const q = new DecayingDeque(1000, () => Promise.resolve(), 12, () => t.fail(), () => t.fail())
+  q.add([...'abcd']).then(c => t.end(c !== 8))
+})
+
+test.cb('should complete the add call as soon as there is capacity again', (t) => {
+  const q = new DecayingDeque(1000, () => Promise.resolve(), 3, () => t.fail(), () => t.fail())
+  q.add([...'abcdef']).then(c => t.end(c !== 1))
+})
+
+test.cb('should decelerate add calls', (t) => {
+  const updates = new Array(1000).fill('x')
+  const q = new DecayingDeque(20,
+    () => new Promise((resolve) => setTimeout(() => resolve())),
+    1000,
+    () => t.fail(),
+    () => t.fail()
+  )
+  updates.reduce((p, v) => p.then(() => q.add([v]).then(c => {
+    // we add a new element as soon as the previous `add` call resolves, and
+    // we expect that this only happens as soon as there is capacity,
+    // so we check that the capacity never falls below 1
+    if (c < 1) t.fail()
+  })), Promise.resolve()).then(() => t.end())
+})
+
+test.cb('should resolve tasks after timing out', (t) => {
+  let r
+  const q = new DecayingDeque(10, () => new Promise((resolve) => (r = resolve)), false, () => t.fail(), (i, p) => {
+    p.then(o => t.end(i !== o))
+    r(i)
+  })
+  q.add(['a'])
+})
+
+test.cb('should rethrow errors for tasks that already timed out', (t) => {
+  let r
+  const q = new DecayingDeque(10, () => new Promise((resolve, reject) => (r = reject)), false, () => t.fail(), (i, p) => {
+    p.catch(o => t.end(i !== o))
+    r(i)
+  })
+  q.add(['a'])
+})
+
+test.cb('should handle concurrent add calls', (t) => {
+  const r = []
+  const q = new DecayingDeque(1000, () => new Promise((resolve) => r.push(resolve)), 3, () => t.fail(), () => t.fail())
+  let count = 0
+  q.add([...'aaaaa']).then(() => ++count)
+  q.add([...'bbbbb']).then(() => ++count)
+  q.add([...'ccccc']).then(() => ++count)
+  q.add([...'ddddd']).then(() => ++count)
+  q.add([...'eeeee']).then(() => t.end(++count !== 5))
+  r.forEach(f => f())
+})
+
+test.cb('should purge many nodes after the same timeout', (t) => {
+  let count = 0
+  const updates = '0123456789'.repeat(10)
+  const q = new DecayingDeque(5, () => new Promise(() => { }), false, () => t.fail(), () => count++)
+  q.add([...updates])
+  setTimeout(() => t.end(count !== updates.length || q.length !== 0), 20)
+})

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -303,27 +303,28 @@ const resStub = {
 
 test.cb('should respect webhookReply option', (t) => {
   const bot = createBot(null, { telegram: { webhookReply: false } })
-  bot.catch((err) => { throw err }) // Disable log
   bot.on('message', ({ reply }) => reply(':)'))
-  t.throwsAsync(bot.handleUpdate({ message: BaseTextMessage }, resStub)).then(() => t.end())
+  bot.catch(() => t.end())
+  bot.handleUpdate({ message: BaseTextMessage }, resStub)
 })
 
 test.cb('should respect webhookReply runtime change', (t) => {
   const bot = createBot()
   bot.webhookReply = false
-  bot.catch((err) => { throw err }) // Disable log
   bot.on('message', (ctx) => ctx.reply(':)'))
 
-  // Throws cause Bot Token is required for http call'
-  t.throwsAsync(bot.handleUpdate({ message: BaseTextMessage }, resStub)).then(() => t.end())
+  // Expect bot to throw cause Bot Token is required for http call
+  bot.catch(() => t.end())
+
+  bot.handleUpdate({ message: BaseTextMessage }, resStub)
 })
 
 test.cb('should respect webhookReply runtime change (per request)', (t) => {
   const bot = createBot()
-  bot.catch((err) => { throw err }) // Disable log
   bot.on('message', async (ctx) => {
     ctx.webhookReply = false
     return ctx.reply(':)')
   })
-  t.throwsAsync(bot.handleUpdate({ message: BaseTextMessage }, resStub)).then(() => t.end())
+  bot.catch(() => t.end())
+  bot.handleUpdate({ message: BaseTextMessage }, resStub)
 })

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -4,6 +4,7 @@ const { Telegraf, session } = require('../')
 function createBot (...args) {
   const bot = new Telegraf(...args)
   bot.botInfo = { id: 42, is_bot: true, username: 'bot', first_name: 'Bot' }
+  bot.initializeQueue(false)
   return bot
 }
 


### PR DESCRIPTION
# Description

This PR implements the decaying deque described in #1234. If you are not familiar with that discussion, you may as well skip reading it and check out the comments in the code first.

If you did read through the main post, I will outline the differences here.

## No timeout pointer

In the original proposal, we stored a reference to the queue head, and we followed the queue upon timeout from the head up to the timeout pointer. However, we already know that the `date` property on the drifts are identical for nodes in a batch, so we can simply use them instead.

## No bulk

We could drop the bulk references the same way as the timeout pointer.

## Different error handling

The error handling is performed almost as described in https://github.com/telegraf/telegraf/discussions/1234#discussioncomment-217223, however, it was simpler to remove the elements right away instead of leaving them in the deque. This also has a better guarantee for when the timeout handler does not make the middleware complete—otherwise, we'd have a lot of elements in the queue that would break the timeout system. However, it should not make a difference to the outside.

## Storing queue containment

The `date` property is set to `-1` if an element is removed. This is to find out whether we should still catch errors, or rethrow them (because the drift had been removed due to timing out).

## Integration of queue and timer

Separating timeout handling and queue implementation is non-trivial. Given that the current file has 80 lines (130 when counting comments and types), and given that the queue implementation only accounts for 20-ish of them, I won't invest the time to do this. If you, however, want to do this, I'm not stopping you.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

I also ran the example bots in order to make sure the updates are processed correctly.

Fixes #735.
Closes #1252.