### PR TITLE
Disable `webhookReply` by default

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -172,6 +172,7 @@ export class Context {
     return this.message?.passport_data
   }
 
+  /** @deprecated use `ctx.telegram.webhookReply` */
   get webhookReply(): boolean {
     return this.tg.webhookReply
   }

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -54,7 +54,7 @@ const DEFAULT_EXTENSIONS: Record<string, string | undefined> = {
 
 const DEFAULT_OPTIONS = {
   apiRoot: 'https://api.telegram.org',
-  webhookReply: true,
+  webhookReply: false,
   agent: new https.Agent({
     keepAlive: true,
     keepAliveMsecs: 10000,

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -34,6 +34,7 @@ namespace ApiClient {
   export interface Options {
     agent?: https.Agent | http.Agent
     apiRoot: string
+    /** @deprecated use `ctx.telegram.webhookReply` */
     webhookReply: boolean
   }
 
@@ -320,7 +321,7 @@ class ApiClient {
   /**
    * If set to `true`, first _eligible_ call will avoid performing a POST request.
    * Note that such a call:
-   * 1. cannot report errors,
+   * 1. cannot report errors or return meaningful value,
    * 2. resolves before bot API has a chance to process it,
    * 3. prematurely confirms the update as processed.
    *

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -317,6 +317,16 @@ class ApiClient {
     }
   }
 
+  /**
+   * If set to `true`, first _eligible_ call will avoid performing a POST request.
+   * Note that such a call:
+   * 1. cannot report errors,
+   * 2. resolves before bot API has a chance to process it,
+   * 3. prematurely confirms the update as processed.
+   *
+   * https://core.telegram.org/bots/faq#how-can-i-make-requests-in-response-to-updates
+   * https://github.com/telegraf/telegraf/pull/1250
+   */
   set webhookReply(enable: boolean) {
     this.options.webhookReply = enable
   }

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -321,7 +321,7 @@ class ApiClient {
   /**
    * If set to `true`, first _eligible_ call will avoid performing a POST request.
    * Note that such a call:
-   * 1. cannot report errors or return meaningful value,
+   * 1. cannot report errors or return meaningful values,
    * 2. resolves before bot API has a chance to process it,
    * 3. prematurely confirms the update as processed.
    *

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -284,8 +284,9 @@ test.cb('should work with context extensions', (t) => {
 
 test.cb('should handle webhook response', (t) => {
   const bot = createBot()
-  bot.on('message', async ({ reply }) => {
-    const result = await reply(':)')
+  bot.on('message', async (ctx) => {
+    ctx.telegram.webhookReply = true
+    const result = await ctx.replyWithChatAction('typing')
     t.deepEqual(result, { webhook: true })
   })
   const res = {


### PR DESCRIPTION
# Description

`webhookReply` is an [endless source of issues](https://github.com/telegraf/telegraf/issues?q=webhookReply). To increase reliability (and reduce the number of "bug" reports), I suggest disabling it by default. Instead, I'd encourage people to enable it on per-call basis and document the gotchas:

1. Errors in the `webhookReply` calls cannot be reported.
2. `webhookReply` calls break ordering by resolving before bot API has a chance to process them (#1167, #1086).
3. `webhookReply` call confirms the update, which means it won't be processed again if bot crashes.

I'm keeping this a draft until I hear @KnorpelSenf opinion on some deprecations I wish to make here:

To discourage enabling `webhookReply` globally, I could deprecate https://github.com/telegraf/telegraf/blob/424f89552509f5490f096800a4843a8e255c5305/src/core/network/client.ts#L37

To avoid duplicating the docs, I could also deprecate https://github.com/telegraf/telegraf/blob/424f89552509f5490f096800a4843a8e255c5305/src/context.ts#L175-L181

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
