### PR TITLE
Don't bind `Context` methods

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -61,15 +61,8 @@ export class Context {
   constructor(
     readonly update: tt.Update,
     readonly tg: Telegram,
-    public readonly botInfo: tt.UserFromGetMe
-  ) {
-    Object.getOwnPropertyNames(Context.prototype)
-      .filter(
-        (key) =>
-          key !== 'constructor' && typeof (this as any)[key] === 'function'
-      )
-      .forEach((key) => ((this as any)[key] = (this as any)[key].bind(this)))
-  }
+    readonly botInfo: tt.UserFromGetMe
+  ) {}
 
   get updateType() {
     return UpdateTypes.find((key) => key in this.update)


### PR DESCRIPTION
# Description

Not useful with `await`.

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
