### PR TITLE
Only include exported members in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,13 +22,13 @@ Telegraf is a library that makes it simple for you to develop your own Telegram 
 
 #### Installation
 
-```bash
+```shellscript
 npm install telegraf --save
 ```
 
 or using yarn
 
-```bash
+```shellscript
 yarn add telegraf
 ```
 
@@ -866,13 +866,13 @@ module.exports = Composer.mount(
 
 To run modules, you can use `telegraf` module runner, it allows you to start Telegraf module easily from the command line.
 
-```bash
+```shellscript
 npm install telegraf -g
 ```
 
 #### Telegraf CLI usage
 
-```plaintext
+```text
 telegraf [opts] <bot-file>
   -t  Bot token [$BOT_TOKEN]
   -d  Webhook domain
@@ -901,7 +901,7 @@ module.exports = bot
 
 then run it:
 
-```bash
+```shellscript
 telegraf -t "bot token" bot.js
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -912,6 +912,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2045,12 +2051,6 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -2559,6 +2559,15 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -2592,9 +2601,9 @@
       }
     },
     "marked": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.5.tgz",
-      "integrity": "sha512-2AlqgYnVPOc9WDyWu7S5DJaEZsfk6dNh/neatQ3IHUW4QLutM/VPSH9lG7bif+XjFWc9K9XR3QvR+fXuECmfdA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
+      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==",
       "dev": true
     },
     "matcher": {
@@ -2851,6 +2860,15 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
       }
     },
     "opencollective-postinstall": {
@@ -3528,6 +3546,48 @@
         "rechoir": "^0.6.2"
       }
     },
+    "shiki": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.7.tgz",
+      "integrity": "sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "shiki-languages": "^0.2.7",
+        "shiki-themes": "^0.2.7",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
+    "shiki-languages": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.7.tgz",
+      "integrity": "sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==",
+      "dev": true,
+      "requires": {
+        "vscode-textmate": "^5.2.0"
+      }
+    },
+    "shiki-themes": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
+      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.1.0",
+        "vscode-textmate": "^5.2.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -3926,28 +3986,28 @@
       }
     },
     "typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "version": "0.20.0-beta.27",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.0-beta.27.tgz",
+      "integrity": "sha512-+TMTlYV7N6mIGEuNIaPEqss3jWOLX2v7rLVz5vT+PfjVgwX+1s+LdPe+plV1hm5Ha1HwFNuVlozXxxWvf95dwA==",
       "dev": true,
       "requires": {
+        "colors": "^1.4.0",
         "fs-extra": "^9.0.1",
         "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
         "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.1.1",
+        "marked": "^1.2.5",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "semver": "^7.3.2",
         "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
+        "shiki": "^0.2.7",
+        "typedoc-default-themes": "0.12.0-beta.10"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "version": "0.12.0-beta.10",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.0-beta.10.tgz",
+      "integrity": "sha512-RqTLRQvzuLrNEZ1VcmYoQiFkixW0QvVUv0R35jlkhxAMGtoo/giUVtWrWY1+Yp7HBnfI/wZKvhZpQYswbDL7eQ==",
       "dev": true
     },
     "typegram": {
@@ -3962,9 +4022,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.0.tgz",
-      "integrity": "sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA==",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.3.tgz",
+      "integrity": "sha512-feZzR+kIcSVuLi3s/0x0b2Tx4Iokwqt+8PJM7yRHKuldg4MLdam4TCFeICv+lgDtuYiCtdmrtIP+uN9LWvDasw==",
       "dev": true,
       "optional": true
     },
@@ -4055,6 +4115,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "wcwidth": {
       "version": "1.0.1",
@@ -4155,6 +4221,12 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
       "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prepare": "npm run build && mjs-entry src/index.ts > lib/index.mjs",
     "build": "tsc --build docs/examples",
-    "build:docs": "typedoc src/index.ts",
+    "build:docs": "typedoc src/index.ts --name telegraf.js",
     "pretest": "npm run build",
     "test": "ava test/*",
     "lint": "eslint --cache .",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prepare": "npm run build && mjs-entry src/index.ts > lib/index.mjs",
     "build": "tsc --build docs/examples",
-    "build:docs": "typedoc src/index.ts --theme minimal",
+    "build:docs": "typedoc src/index.ts",
     "pretest": "npm run build",
     "test": "ava test/*",
     "lint": "eslint --cache .",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prepare": "npm run build && mjs-entry src/index.ts > lib/index.mjs",
     "build": "tsc --build docs/examples",
-    "build:docs": "typedoc",
+    "build:docs": "typedoc src/index.ts --theme minimal",
     "pretest": "npm run build",
     "test": "ava test/*",
     "lint": "eslint --cache .",
@@ -79,7 +79,7 @@
     "husky": "^4.3.0",
     "mjs-entry": "gist:de6257751f54b3c66319bae8d2a8aea0",
     "prettier": "2.2.0",
-    "typedoc": "^0.19.2",
+    "typedoc": "^0.20.0-beta.27",
     "typescript": "^4.1.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prepare": "npm run build && mjs-entry src/index.ts > lib/index.mjs",
     "build": "tsc --build docs/examples",
-    "build:docs": "typedoc src/index.ts --name telegraf.js",
+    "build:docs": "typedoc src/index.ts",
     "pretest": "npm run build",
     "test": "ava test/*",
     "lint": "eslint --cache .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "typedocOptions": {
     "excludeExternals": true,
+    "name": "telegraf.js",
     "mode": "file",
     "out": "docs/build/",
     "readme": "docs/README.md",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,3 +1,0 @@
-{
-  "name": "telegraf.js"
-}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "name": "telegraf.js"
+}


### PR DESCRIPTION
# Description

Updates `typedoc` to a beta version in order to remove clutter from the generated docs by reducing the displayed entities to those that `telegraf` actually `export`s.

Also, switching to the `minimal` theme gives the docs a much better overview.

## Type of change

Config update

# How Has This Been Tested?

`npm run build:docs`

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
