### PR TITLE
Fix error handler type

### DIFF
--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -112,9 +112,8 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
   webhookCallback(path = '/') {
     return generateCallback(
       path,
-      async (update: tt.Update, res: http.ServerResponse) => {
-        await this.handleUpdate(update, res)
-      },
+      (update: tt.Update, res: http.ServerResponse) =>
+        this.handleUpdate(update, res),
       debug
     )
   }
@@ -220,7 +219,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     try {
       await this.middleware()(ctx, anoop)
     } catch (err) {
-      return await this.handleError(err, ctx)
+      await this.handleError(err, ctx)
     } finally {
       if (webhookResponse !== undefined && !webhookResponse.writableEnded) {
         webhookResponse.end()


### PR DESCRIPTION
# Description

Aligns the error handler return type with the middleware return type, basically #1156 for the error handler.
## Type of change

Types.

# How Has This Been Tested?

```
npm run test
npm run lint
```

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
