### PR TITLE
Add `ctx.telegram2`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,5 @@
 import * as tt from './telegram-types'
+import { Telegram2, telegram2 } from './telegram2'
 import ApiClient from './core/network/client'
 import Telegram from './telegram'
 
@@ -58,12 +59,16 @@ export const MessageSubTypes = [
 
 export class Context {
   readonly state: Record<string | symbol, any> = {}
+  readonly telegram2: Telegram2
 
   constructor(
     readonly update: tt.Update,
+    /** @deprecated use `ctx.telegram2` */
     readonly tg: Telegram,
     readonly botInfo: tt.UserFromGetMe
-  ) {}
+  ) {
+    this.telegram2 = telegram2(tg)
+  }
 
   get updateType() {
     return UpdateTypes.find((key) => key in this.update)
@@ -73,6 +78,7 @@ export class Context {
     return this.botInfo?.username
   }
 
+  /** @deprecated use `ctx.telegram2` */
   get telegram() {
     return this.tg
   }
@@ -542,10 +548,12 @@ export class Context {
     return this.telegram.addStickerToSet(this.from.id, ...args)
   }
 
+  /** @deprecated use `this.telegram2.getMyCommands` */
   getMyCommands() {
     return this.telegram.getMyCommands()
   }
 
+  /** @deprecated use `this.telegram2.setMyCommands` */
   setMyCommands(commands: readonly tt.BotCommand[]) {
     return this.telegram.setMyCommands(commands)
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -58,8 +58,10 @@ export const MessageSubTypes = [
 ] as const
 
 export class Context {
-  readonly state: Record<string | symbol, any> = {}
+  /** Allows to make bot API requests not covered by the shorthands */
   readonly telegram2: Telegram2
+  /** Weakly-typed namespace for sharing data between middlewares */
+  readonly state: Record<string | symbol, any> = {}
 
   constructor(
     readonly update: tt.Update,

--- a/src/context.ts
+++ b/src/context.ts
@@ -65,7 +65,6 @@ export class Context {
 
   constructor(
     readonly update: tt.Update,
-    /** @deprecated use `ctx.telegram2` */
     readonly tg: Telegram,
     readonly botInfo: tt.UserFromGetMe
   ) {
@@ -80,7 +79,6 @@ export class Context {
     return this.botInfo?.username
   }
 
-  /** @deprecated use `ctx.telegram2` */
   get telegram() {
     return this.tg
   }

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -36,6 +36,7 @@ export type InputFile =
 type TelegrafTypegram = Typegram<InputFile>
 
 export type Telegram = TelegrafTypegram['Telegram']
+export type TelegramP = TelegrafTypegram['TelegramP']
 export type Opts<M extends keyof Telegram> = TelegrafTypegram['Opts'][M]
 export type InputMedia = TelegrafTypegram['InputMedia']
 export type InputMediaPhoto = TelegrafTypegram['InputMediaPhoto']

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -2,7 +2,6 @@ import * as tt from './telegram-types'
 import ApiClient from './core/network/client'
 import { isAbsolute } from 'path'
 
-/** @deprecated use `telegram2` */
 class Telegram extends ApiClient {
   /**
    * Get basic information about the bot

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -2,6 +2,7 @@ import * as tt from './telegram-types'
 import ApiClient from './core/network/client'
 import { isAbsolute } from 'path'
 
+/** @deprecated use `telegram2` */
 class Telegram extends ApiClient {
   /**
    * Get basic information about the bot

--- a/src/telegram2.ts
+++ b/src/telegram2.ts
@@ -1,0 +1,24 @@
+import ApiClient from './core/network/client'
+import { TelegramP } from './telegram-types'
+
+type BasicApiClient = Readonly<Pick<ApiClient, 'callApi'>>
+export type Telegram2 = Readonly<BasicApiClient & TelegramP>
+
+const proxyHandler: ProxyHandler<BasicApiClient> = {
+  get(target, p: keyof Telegram2) {
+    if (p === 'callApi') {
+      return target[p]
+    }
+    return target.callApi.bind(target, p)
+  },
+  set() {
+    return false
+  },
+  ownKeys() {
+    return []
+  },
+}
+
+export function telegram2(client: BasicApiClient) {
+  return new Proxy(client, proxyHandler) as Telegram2
+}

--- a/src/telegram2.ts
+++ b/src/telegram2.ts
@@ -14,6 +14,12 @@ const proxyHandler: ProxyHandler<BasicApiClient> = {
   set() {
     return false
   },
+  defineProperty() {
+    return false
+  },
+  deleteProperty() {
+    return false
+  },
   ownKeys() {
     return []
   },

--- a/src/telegram2.ts
+++ b/src/telegram2.ts
@@ -7,7 +7,7 @@ export type Telegram2 = Readonly<BasicApiClient & TelegramP>
 const proxyHandler: ProxyHandler<BasicApiClient> = {
   get(target, p: keyof Telegram2) {
     if (p === 'callApi') {
-      return target[p]
+      return target.callApi.bind(target)
     }
     return target.callApi.bind(target, p)
   },


### PR DESCRIPTION
# Description

Does everything* `ctx.telegram` does, but in 980 lines less, and automatically updates with `typegram`.

\* Notable omissions: `getFileLink`, writable `callApi`.

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update



# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
