### PR TITLE
`p-timeout` update handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2926,6 +2926,17 @@
       "dev": true,
       "requires": {
         "p-timeout": "^3.1.0"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "dev": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        }
       }
     },
     "p-finally": {
@@ -2962,13 +2973,9 @@
       }
     },
     "p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "dev": true,
-      "requires": {
-        "p-finally": "^1.0.0"
-      }
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw=="
     },
     "p-try": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "minimist": "^1.2.5",
     "module-alias": "^2.2.2",
     "node-fetch": "^2.6.1",
+    "p-timeout": "^4.1.0",
     "sandwich-stream": "^2.0.2",
     "typegram": "^3.0.0"
   },

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -387,7 +387,7 @@ class ApiClient {
     const apiUrl = `${options.apiRoot}/bot${token}/${method}`
     config.agent = options.agent
     config.signal = signal
-    config.timeout = 120000 // 2 minutes
+    config.timeout = 60_000 // 60s in ms
     const res = await fetch(apiUrl, config)
     const data = await res.json()
     if (!data.ok) {

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -10,6 +10,7 @@ import Context from './context'
 import d from 'debug'
 import generateCallback from './core/network/webhook'
 import { Polling } from './core/network/polling'
+import pTimeout from 'p-timeout'
 import Telegram from './telegram'
 import { TlsOptions } from 'tls'
 import { URL } from 'url'
@@ -17,7 +18,7 @@ const debug = d('telegraf:main')
 
 const DEFAULT_OPTIONS: Telegraf.Options<Context> = {
   telegram: {},
-  handlerTimeout: 5000,
+  handlerTimeout: 90_000, // 90s in ms
   contextType: Context,
 }
 
@@ -25,7 +26,6 @@ function always<T>(x: T) {
   return () => x
 }
 const anoop = always(Promise.resolve())
-const wait = util.promisify(setTimeout)
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Telegraf {
@@ -189,12 +189,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     if (!Array.isArray(updates)) {
       throw new TypeError(util.format('Updates must be an array, got', updates))
     }
-    // prettier-ignore
-    const processAll = Promise.all(updates.map((update) => this.handleUpdate(update)))
-    if (this.options.handlerTimeout === Infinity) {
-      return processAll
-    }
-    return Promise.race([processAll, wait(this.options.handlerTimeout)])
+    return Promise.all(updates.map((update) => this.handleUpdate(update)))
   }
 
   private botInfoCall?: Promise<tt.UserFromGetMe>
@@ -212,7 +207,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     const ctx = new TelegrafContext(update, tg, this.botInfo)
     Object.assign(ctx, this.context)
     try {
-      await this.middleware()(ctx, anoop)
+      await pTimeout(this.middleware()(ctx, anoop), this.options.handlerTimeout)
     } catch (err) {
       return await this.handleError(err, ctx)
     } finally {

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -207,7 +207,10 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     const ctx = new TelegrafContext(update, tg, this.botInfo)
     Object.assign(ctx, this.context)
     try {
-      await pTimeout(this.middleware()(ctx, anoop), this.options.handlerTimeout)
+      await pTimeout(
+        Promise.resolve(this.middleware()(ctx, anoop)),
+        this.options.handlerTimeout
+      )
     } catch (err) {
       return await this.handleError(err, ctx)
     } finally {


### PR DESCRIPTION
# Description

Truthfully, anything more complex is "a premature performance optimization that is not backed by runtime analyses or performance tests". See https://stackoverflow.com/a/13616530. Closes #1247. Closes #1252.

Would you be fine if I changed `MiddlewareFn` to return `Promise<unknown>`? It's the simplest solution to the type error.

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

# How Has This Been Tested?

Purposefully timing out. Also, I ensured that graceful stop continues to work.

<!--
CI typechecks, lints and runs the test suite.
If you did any extra manual tests, please describe them here.

**Test Configuration**:
* Node.js Version:
* Operating System:
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
