### PR TITLE
Alias `Composer.mount` to `Composer.on`

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -392,8 +392,19 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
 
   /**
    * Generates middleware for handling provided update types.
+   * @deprecated use `Composer.on`
    */
   static mount<C extends Context, T extends tt.UpdateType | tt.MessageSubType>(
+    updateType: MaybeArray<T>,
+    ...fns: NonemptyReadonlyArray<Middleware<MatchedContext<C, T>>>
+  ): MiddlewareFn<C> {
+    return Composer.on(updateType, ...fns)
+  }
+
+  /**
+   * Generates middleware for handling provided update types.
+   */
+  static on<C extends Context, T extends tt.UpdateType | tt.MessageSubType>(
     updateType: MaybeArray<T>,
     ...fns: NonemptyReadonlyArray<Middleware<MatchedContext<C, T>>>
   ): MiddlewareFn<C> {


### PR DESCRIPTION
# Description

`Composer.mount` is the only static method named differently than its instance counterpart.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
