### PR TITLE
Add `Scenes` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,45 +652,6 @@ bot.on('photo', (ctx, next) => {
 
 Coming soon!
 
-#### Stage
+### `Scenes` namespace
 
-Simple scene-based control flow middleware.
-
-```js
-const { Telegraf } = require('telegraf')
-const session = require('telegraf/session')
-const Stage = require('telegraf/stage')
-const Scene = require('telegraf/scenes/base')
-const { leave } = Stage
-
-// Greeter scene
-const greeter = new Scene('greeter')
-greeter.enter((ctx) => ctx.reply('Hi'))
-greeter.leave((ctx) => ctx.reply('Bye'))
-greeter.hears(/hi/gi, leave())
-greeter.on('message', (ctx) => ctx.reply('Send `hi`'))
-
-// Create scene manager
-const stage = new Stage()
-stage.command('cancel', leave())
-
-// Scene registration
-stage.register(greeter)
-
-const bot = new Telegraf(process.env.BOT_TOKEN)
-bot.use(session())
-bot.use(stage.middleware())
-bot.command('greeter', (ctx) => ctx.scene.enter('greeter'))
-bot.startPolling()
-```
-
-Scenes related context props and functions:
-
-```js
-bot.on('message', (ctx) => {
-  ctx.scene.state                                    // Current scene state (persistent)
-  ctx.scene.enter(sceneId, [defaultState, silent])   // Enter scene
-  ctx.scene.reenter()                                // Reenter current scene
-  ctx.scene.leave()                                  // Leave scene
-})
-```
+https://github.com/telegraf/telegraf/issues/705#issuecomment-549056045

--- a/docs/examples/scenes/scenes-bot-custom-context-and-scene-session.ts
+++ b/docs/examples/scenes/scenes-bot-custom-context-and-scene-session.ts
@@ -1,13 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Context,
-  BaseScene as Scene,
-  SceneContextScene,
-  SceneSessionData,
-  session,
-  Stage,
-  Telegraf,
-} from 'telegraf'
+import { Context, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -19,7 +11,7 @@ if (token === undefined) {
  * This can be done by extending `SceneSessionData` and in turn passing your own
  * interface as a type variable to `SceneContextScene`.
  */
-interface MySceneSession extends SceneSessionData {
+interface MySceneSession extends Scenes.SceneSessionData {
   // will be available under `ctx.scene.session.mySceneSessionProp`
   mySceneSessionProp: number
 }
@@ -35,21 +27,21 @@ interface MyContext extends Context {
   myContextProp: string
 
   // declare scene type
-  scene: SceneContextScene<MyContext, MySceneSession>
+  scene: Scenes.SceneContextScene<MyContext, MySceneSession>
 }
 
 // Handler factories
-const { enter, leave } = Stage
+const { enter, leave } = Scenes.Stage
 
 // Greeter scene
-const greeterScene = new Scene<MyContext>('greeter')
+const greeterScene = new Scenes.BaseScene<MyContext>('greeter')
 greeterScene.enter((ctx) => ctx.reply('Hi'))
 greeterScene.leave((ctx) => ctx.reply('Bye'))
 greeterScene.hears('hi', enter<MyContext>('greeter'))
 greeterScene.on('message', (ctx) => ctx.replyWithMarkdown('Send `hi`'))
 
 // Echo scene
-const echoScene = new Scene<MyContext>('echo')
+const echoScene = new Scenes.BaseScene<MyContext>('echo')
 echoScene.enter((ctx) => ctx.reply('echo scene'))
 echoScene.leave((ctx) => ctx.reply('exiting echo scene'))
 echoScene.command('back', leave<MyContext>())
@@ -58,7 +50,7 @@ echoScene.on('message', (ctx) => ctx.reply('Only text messages please'))
 
 const bot = new Telegraf<MyContext>(token)
 
-const stage = new Stage<MyContext>([greeterScene, echoScene], {
+const stage = new Scenes.Stage<MyContext>([greeterScene, echoScene], {
   ttl: 10,
 })
 bot.use(session())

--- a/docs/examples/scenes/scenes-bot-custom-context-and-session-and-scene-session.ts
+++ b/docs/examples/scenes/scenes-bot-custom-context-and-session-and-scene-session.ts
@@ -1,14 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Context,
-  BaseScene as Scene,
-  SceneContextScene,
-  SceneSession,
-  SceneSessionData,
-  session,
-  Stage,
-  Telegraf,
-} from 'telegraf'
+import { Context, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -20,7 +11,7 @@ if (token === undefined) {
  * This can be done by extending `SceneSessionData` and in turn passing your own
  * interface as a type variable to `SceneSession` and to `SceneContextScene`.
  */
-interface MySceneSession extends SceneSessionData {
+interface MySceneSession extends Scenes.SceneSessionData {
   // will be available under `ctx.scene.session.mySceneSessionProp`
   mySceneSessionProp: number
 }
@@ -33,7 +24,7 @@ interface MySceneSession extends SceneSessionData {
  * It is possible to pass a type variable to `SceneSession` if you also want to
  * extend the scene session as we do above.
  */
-interface MySession extends SceneSession<MySceneSession> {
+interface MySession extends Scenes.SceneSession<MySceneSession> {
   // will be available under `ctx.session.mySessionProp`
   mySessionProp: number
 }
@@ -53,21 +44,21 @@ interface MyContext extends Context {
   // declare session type
   session: MySession
   // declare scene type
-  scene: SceneContextScene<MyContext, MySceneSession>
+  scene: Scenes.SceneContextScene<MyContext, MySceneSession>
 }
 
 // Handler factories
-const { enter, leave } = Stage
+const { enter, leave } = Scenes.Stage
 
 // Greeter scene
-const greeterScene = new Scene<MyContext>('greeter')
+const greeterScene = new Scenes.BaseScene<MyContext>('greeter')
 greeterScene.enter((ctx) => ctx.reply('Hi'))
 greeterScene.leave((ctx) => ctx.reply('Bye'))
 greeterScene.hears('hi', enter<MyContext>('greeter'))
 greeterScene.on('message', (ctx) => ctx.replyWithMarkdown('Send `hi`'))
 
 // Echo scene
-const echoScene = new Scene<MyContext>('echo')
+const echoScene = new Scenes.BaseScene<MyContext>('echo')
 echoScene.enter((ctx) => ctx.reply('echo scene'))
 echoScene.leave((ctx) => ctx.reply('exiting echo scene'))
 echoScene.command('back', leave<MyContext>())
@@ -76,7 +67,7 @@ echoScene.on('message', (ctx) => ctx.reply('Only text messages please'))
 
 const bot = new Telegraf<MyContext>(token)
 
-const stage = new Stage<MyContext>([greeterScene, echoScene], {
+const stage = new Scenes.Stage<MyContext>([greeterScene, echoScene], {
   ttl: 10,
 })
 bot.use(session())

--- a/docs/examples/scenes/scenes-bot-custom-context-and-session.ts
+++ b/docs/examples/scenes/scenes-bot-custom-context-and-session.ts
@@ -1,13 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Context,
-  BaseScene as Scene,
-  SceneContextScene,
-  SceneSession,
-  session,
-  Stage,
-  Telegraf,
-} from 'telegraf'
+import { Context, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -18,7 +10,7 @@ if (token === undefined) {
  * We can extend the regular session object that we can use on the context.
  * However, as we're using scenes, we have to make it extend `SceneSession`.
  */
-interface MySession extends SceneSession {
+interface MySession extends Scenes.SceneSession {
   // will be available under `ctx.session.mySessionProp`
   mySessionProp: number
 }
@@ -37,21 +29,21 @@ interface MyContext extends Context {
   // declare session type
   session: MySession
   // declare scene type
-  scene: SceneContextScene<MyContext>
+  scene: Scenes.SceneContextScene<MyContext>
 }
 
 // Handler factories
-const { enter, leave } = Stage
+const { enter, leave } = Scenes.Stage
 
 // Greeter scene
-const greeterScene = new Scene<MyContext>('greeter')
+const greeterScene = new Scenes.BaseScene<MyContext>('greeter')
 greeterScene.enter((ctx) => ctx.reply('Hi'))
 greeterScene.leave((ctx) => ctx.reply('Bye'))
 greeterScene.hears('hi', enter<MyContext>('greeter'))
 greeterScene.on('message', (ctx) => ctx.replyWithMarkdown('Send `hi`'))
 
 // Echo scene
-const echoScene = new Scene<MyContext>('echo')
+const echoScene = new Scenes.BaseScene<MyContext>('echo')
 echoScene.enter((ctx) => ctx.reply('echo scene'))
 echoScene.leave((ctx) => ctx.reply('exiting echo scene'))
 echoScene.command('back', leave<MyContext>())
@@ -60,7 +52,7 @@ echoScene.on('message', (ctx) => ctx.reply('Only text messages please'))
 
 const bot = new Telegraf<MyContext>(token)
 
-const stage = new Stage<MyContext>([greeterScene, echoScene], {
+const stage = new Scenes.Stage<MyContext>([greeterScene, echoScene], {
   ttl: 10,
 })
 bot.use(session())

--- a/docs/examples/scenes/scenes-bot-custom-context.ts
+++ b/docs/examples/scenes/scenes-bot-custom-context.ts
@@ -1,12 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Context,
-  BaseScene as Scene,
-  SceneContextScene,
-  session,
-  Stage,
-  Telegraf,
-} from 'telegraf'
+import { Context, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -23,21 +16,21 @@ interface MyContext extends Context {
   myContextProp: string
 
   // declare scene type
-  scene: SceneContextScene<MyContext>
+  scene: Scenes.SceneContextScene<MyContext>
 }
 
 // Handler factories
-const { enter, leave } = Stage
+const { enter, leave } = Scenes.Stage
 
 // Greeter scene
-const greeterScene = new Scene<MyContext>('greeter')
+const greeterScene = new Scenes.BaseScene<MyContext>('greeter')
 greeterScene.enter((ctx) => ctx.reply('Hi'))
 greeterScene.leave((ctx) => ctx.reply('Bye'))
 greeterScene.hears('hi', enter<MyContext>('greeter'))
 greeterScene.on('message', (ctx) => ctx.replyWithMarkdown('Send `hi`'))
 
 // Echo scene
-const echoScene = new Scene<MyContext>('echo')
+const echoScene = new Scenes.BaseScene<MyContext>('echo')
 echoScene.enter((ctx) => ctx.reply('echo scene'))
 echoScene.leave((ctx) => ctx.reply('exiting echo scene'))
 echoScene.command('back', leave<MyContext>())
@@ -46,7 +39,7 @@ echoScene.on('message', (ctx) => ctx.reply('Only text messages please'))
 
 const bot = new Telegraf<MyContext>(token)
 
-const stage = new Stage<MyContext>([greeterScene, echoScene], {
+const stage = new Scenes.Stage<MyContext>([greeterScene, echoScene], {
   ttl: 10,
 })
 bot.use(session())

--- a/docs/examples/scenes/scenes-bot-custom-scene-session.ts
+++ b/docs/examples/scenes/scenes-bot-custom-scene-session.ts
@@ -1,12 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  BaseScene as Scene,
-  SceneContext,
-  SceneSessionData,
-  session,
-  Stage,
-  Telegraf,
-} from 'telegraf'
+import { Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -18,25 +11,25 @@ if (token === undefined) {
  * This can be done by extending `SceneSessionData` and in turn passing your own
  * interface as a type variable to `SceneContext`.
  */
-interface MySceneSession extends SceneSessionData {
+interface MySceneSession extends Scenes.SceneSessionData {
   // will be available under `ctx.scene.session.mySceneSessionProp`
   mySceneSessionProp: number
 }
 
-type MyContext = SceneContext<MySceneSession>
+type MyContext = Scenes.SceneContext<MySceneSession>
 
 // Handler factories
-const { enter, leave } = Stage
+const { enter, leave } = Scenes.Stage
 
 // Greeter scene
-const greeterScene = new Scene<MyContext>('greeter')
+const greeterScene = new Scenes.BaseScene<MyContext>('greeter')
 greeterScene.enter((ctx) => ctx.reply('Hi'))
 greeterScene.leave((ctx) => ctx.reply('Bye'))
 greeterScene.hears('hi', enter<MyContext>('greeter'))
 greeterScene.on('message', (ctx) => ctx.replyWithMarkdown('Send `hi`'))
 
 // Echo scene
-const echoScene = new Scene<MyContext>('echo')
+const echoScene = new Scenes.BaseScene<MyContext>('echo')
 echoScene.enter((ctx) => ctx.reply('echo scene'))
 echoScene.leave((ctx) => ctx.reply('exiting echo scene'))
 echoScene.command('back', leave<MyContext>())
@@ -45,7 +38,7 @@ echoScene.on('message', (ctx) => ctx.reply('Only text messages please'))
 
 const bot = new Telegraf<MyContext>(token)
 
-const stage = new Stage<MyContext>([greeterScene, echoScene], {
+const stage = new Scenes.Stage<MyContext>([greeterScene, echoScene], {
   ttl: 10,
 })
 bot.use(session())

--- a/docs/examples/scenes/scenes-bot.ts
+++ b/docs/examples/scenes/scenes-bot.ts
@@ -1,11 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  BaseScene as Scene,
-  SceneContext,
-  session,
-  Stage,
-  Telegraf,
-} from 'telegraf'
+import { Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -13,26 +7,26 @@ if (token === undefined) {
 }
 
 // Handler factories
-const { enter, leave } = Stage
+const { enter, leave } = Scenes.Stage
 
 // Greeter scene
-const greeterScene = new Scene<SceneContext>('greeter')
+const greeterScene = new Scenes.BaseScene<Scenes.SceneContext>('greeter')
 greeterScene.enter((ctx) => ctx.reply('Hi'))
 greeterScene.leave((ctx) => ctx.reply('Bye'))
-greeterScene.hears('hi', enter<SceneContext>('greeter'))
+greeterScene.hears('hi', enter<Scenes.SceneContext>('greeter'))
 greeterScene.on('message', (ctx) => ctx.replyWithMarkdown('Send `hi`'))
 
 // Echo scene
-const echoScene = new Scene<SceneContext>('echo')
+const echoScene = new Scenes.BaseScene<Scenes.SceneContext>('echo')
 echoScene.enter((ctx) => ctx.reply('echo scene'))
 echoScene.leave((ctx) => ctx.reply('exiting echo scene'))
-echoScene.command('back', leave<SceneContext>())
+echoScene.command('back', leave<Scenes.SceneContext>())
 echoScene.on('text', (ctx) => ctx.reply(ctx.message.text))
 echoScene.on('message', (ctx) => ctx.reply('Only text messages please'))
 
-const bot = new Telegraf<SceneContext>(token)
+const bot = new Telegraf<Scenes.SceneContext>(token)
 
-const stage = new Stage<SceneContext>([greeterScene, echoScene], {
+const stage = new Scenes.Stage<Scenes.SceneContext>([greeterScene, echoScene], {
   ttl: 10,
 })
 bot.use(session())

--- a/docs/examples/wizards/wizard-bot-custom-context-and-scene-session.ts
+++ b/docs/examples/wizards/wizard-bot-custom-context-and-scene-session.ts
@@ -1,16 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Composer,
-  Context,
-  Markup,
-  SceneContextScene,
-  session,
-  Stage,
-  Telegraf,
-  WizardContextWizard,
-  WizardScene,
-  WizardSessionData,
-} from 'telegraf'
+import { Composer, Context, Markup, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -22,7 +11,7 @@ if (token === undefined) {
  * This can be done by extending `WizardSessionData` and in turn passing your
  * own interface as a type variable to `WizardContextWizard`.
  */
-interface MyWizardSession extends WizardSessionData {
+interface MyWizardSession extends Scenes.WizardSessionData {
   // will be available under `ctx.scene.session.myWizardSessionProp`
   myWizardSessionProp: number
 }
@@ -40,9 +29,9 @@ interface MyContext extends Context {
   myContextProp: string
 
   // declare scene type
-  scene: SceneContextScene<MyContext, MyWizardSession>
+  scene: Scenes.SceneContextScene<MyContext, MyWizardSession>
   // declare wizard type
-  wizard: WizardContextWizard<MyContext>
+  wizard: Scenes.WizardContextWizard<MyContext>
 }
 
 const stepHandler = new Composer<MyContext>()
@@ -58,7 +47,7 @@ stepHandler.use((ctx) =>
   ctx.replyWithMarkdown('Press `Next` button or type /next')
 )
 
-const superWizard = new WizardScene(
+const superWizard = new Scenes.WizardScene(
   'super-wizard',
   async (ctx) => {
     await ctx.reply(
@@ -92,7 +81,7 @@ const superWizard = new WizardScene(
 )
 
 const bot = new Telegraf<MyContext>(token)
-const stage = new Stage<MyContext>([superWizard], {
+const stage = new Scenes.Stage<MyContext>([superWizard], {
   default: 'super-wizard',
 })
 bot.use(session())

--- a/docs/examples/wizards/wizard-bot-custom-context-and-session-and-scene-session.ts
+++ b/docs/examples/wizards/wizard-bot-custom-context-and-session-and-scene-session.ts
@@ -1,17 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Composer,
-  Context,
-  Markup,
-  SceneContextScene,
-  session,
-  Stage,
-  Telegraf,
-  WizardContextWizard,
-  WizardScene,
-  WizardSession,
-  WizardSessionData,
-} from 'telegraf'
+import { Composer, Context, Markup, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -24,7 +12,7 @@ if (token === undefined) {
  * own interface as a type variable to `WizardSession` and to
  * `WizardContextWizard`.
  */
-interface MyWizardSession extends WizardSessionData {
+interface MyWizardSession extends Scenes.WizardSessionData {
   // will be available under `ctx.scene.session.myWizardSessionProp`
   myWizardSessionProp: number
 }
@@ -37,7 +25,7 @@ interface MyWizardSession extends WizardSessionData {
  * It is possible to pass a type variable to `WizardSession` if you also want to
  * extend the wizard session as we do above.
  */
-interface MySession extends WizardSession<MyWizardSession> {
+interface MySession extends Scenes.WizardSession<MyWizardSession> {
   // will be available under `ctx.session.mySessionProp`
   mySessionProp: number
 }
@@ -59,9 +47,9 @@ interface MyContext extends Context {
   // declare session type
   session: MySession
   // declare scene type
-  scene: SceneContextScene<MyContext, MyWizardSession>
+  scene: Scenes.SceneContextScene<MyContext, MyWizardSession>
   // declare wizard type
-  wizard: WizardContextWizard<MyContext>
+  wizard: Scenes.WizardContextWizard<MyContext>
 }
 
 const stepHandler = new Composer<MyContext>()
@@ -77,7 +65,7 @@ stepHandler.use((ctx) =>
   ctx.replyWithMarkdown('Press `Next` button or type /next')
 )
 
-const superWizard = new WizardScene(
+const superWizard = new Scenes.WizardScene(
   'super-wizard',
   async (ctx) => {
     await ctx.reply(
@@ -112,7 +100,7 @@ const superWizard = new WizardScene(
 )
 
 const bot = new Telegraf<MyContext>(token)
-const stage = new Stage<MyContext>([superWizard], {
+const stage = new Scenes.Stage<MyContext>([superWizard], {
   default: 'super-wizard',
 })
 bot.use(session())

--- a/docs/examples/wizards/wizard-bot-custom-context-and-session.ts
+++ b/docs/examples/wizards/wizard-bot-custom-context-and-session.ts
@@ -1,17 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Composer,
-  Context,
-  Markup,
-  SceneContextScene,
-  session,
-  Stage,
-  Telegraf,
-  WizardContextWizard,
-  WizardScene,
-  WizardSession,
-  WizardSessionData,
-} from 'telegraf'
+import { Composer, Context, Markup, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -22,7 +10,7 @@ if (token === undefined) {
  * We can extend the regular session object that we can use on the context.
  * However, as we're using wizards, we have to make it extend `WizardSession`.
  */
-interface MySession extends WizardSession {
+interface MySession extends Scenes.WizardSession {
   // will be available under `ctx.session.mySessionProp`
   mySessionProp: number
 }
@@ -44,9 +32,9 @@ interface MyContext extends Context {
   // declare session type
   session: MySession
   // declare scene type
-  scene: SceneContextScene<MyContext, WizardSessionData>
+  scene: Scenes.SceneContextScene<MyContext, Scenes.WizardSessionData>
   // declare wizard type
-  wizard: WizardContextWizard<MyContext>
+  wizard: Scenes.WizardContextWizard<MyContext>
 }
 
 const stepHandler = new Composer<MyContext>()
@@ -62,7 +50,7 @@ stepHandler.use((ctx) =>
   ctx.replyWithMarkdown('Press `Next` button or type /next')
 )
 
-const superWizard = new WizardScene(
+const superWizard = new Scenes.WizardScene(
   'super-wizard',
   async (ctx) => {
     await ctx.reply(
@@ -96,7 +84,7 @@ const superWizard = new WizardScene(
 )
 
 const bot = new Telegraf<MyContext>(token)
-const stage = new Stage<MyContext>([superWizard], {
+const stage = new Scenes.Stage<MyContext>([superWizard], {
   default: 'super-wizard',
 })
 bot.use(session())

--- a/docs/examples/wizards/wizard-bot-custom-context.ts
+++ b/docs/examples/wizards/wizard-bot-custom-context.ts
@@ -1,16 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Composer,
-  Context,
-  Markup,
-  SceneContextScene,
-  session,
-  Stage,
-  Telegraf,
-  WizardContextWizard,
-  WizardScene,
-  WizardSessionData,
-} from 'telegraf'
+import { Composer, Context, Markup, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -30,9 +19,9 @@ interface MyContext extends Context {
   myContextProp: string
 
   // declare scene type
-  scene: SceneContextScene<MyContext, WizardSessionData>
+  scene: Scenes.SceneContextScene<MyContext, Scenes.WizardSessionData>
   // declare wizard type
-  wizard: WizardContextWizard<MyContext>
+  wizard: Scenes.WizardContextWizard<MyContext>
 }
 
 const stepHandler = new Composer<MyContext>()
@@ -48,7 +37,7 @@ stepHandler.use((ctx) =>
   ctx.replyWithMarkdown('Press `Next` button or type /next')
 )
 
-const superWizard = new WizardScene(
+const superWizard = new Scenes.WizardScene(
   'super-wizard',
   async (ctx) => {
     await ctx.reply(
@@ -81,7 +70,7 @@ const superWizard = new WizardScene(
 )
 
 const bot = new Telegraf<MyContext>(token)
-const stage = new Stage<MyContext>([superWizard], {
+const stage = new Scenes.Stage<MyContext>([superWizard], {
   default: 'super-wizard',
 })
 bot.use(session())

--- a/docs/examples/wizards/wizard-bot-custom-scene-session.ts
+++ b/docs/examples/wizards/wizard-bot-custom-scene-session.ts
@@ -1,14 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Composer,
-  Markup,
-  session,
-  Stage,
-  Telegraf,
-  WizardContext,
-  WizardScene,
-  WizardSessionData,
-} from 'telegraf'
+import { Composer, Markup, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -20,12 +11,12 @@ if (token === undefined) {
  * This can be done by extending `WizardSessionData` and in turn passing your
  * own interface as a type variable to `WizardContext`.
  */
-interface MyWizardSession extends WizardSessionData {
+interface MyWizardSession extends Scenes.WizardSessionData {
   // will be available under `ctx.scene.session.myWizardSessionProp`
   myWizardSessionProp: number
 }
 
-type MyContext = WizardContext<MyWizardSession>
+type MyContext = Scenes.WizardContext<MyWizardSession>
 
 const stepHandler = new Composer<MyContext>()
 stepHandler.action('next', async (ctx) => {
@@ -40,7 +31,7 @@ stepHandler.use((ctx) =>
   ctx.replyWithMarkdown('Press `Next` button or type /next')
 )
 
-const superWizard = new WizardScene(
+const superWizard = new Scenes.WizardScene(
   'super-wizard',
   async (ctx) => {
     await ctx.reply(
@@ -73,7 +64,7 @@ const superWizard = new WizardScene(
 )
 
 const bot = new Telegraf<MyContext>(token)
-const stage = new Stage<MyContext>([superWizard], {
+const stage = new Scenes.Stage<MyContext>([superWizard], {
   default: 'super-wizard',
 })
 bot.use(session())

--- a/docs/examples/wizards/wizard-bot.ts
+++ b/docs/examples/wizards/wizard-bot.ts
@@ -1,20 +1,12 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-  Composer,
-  Markup,
-  session,
-  Stage,
-  Telegraf,
-  WizardContext,
-  WizardScene,
-} from 'telegraf'
+import { Composer, Markup, Scenes, session, Telegraf } from 'telegraf'
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
   throw new Error('BOT_TOKEN must be provided!')
 }
 
-const stepHandler = new Composer<WizardContext>()
+const stepHandler = new Composer<Scenes.WizardContext>()
 stepHandler.action('next', async (ctx) => {
   await ctx.reply('Step 2. Via inline button')
   return ctx.wizard.next()
@@ -27,7 +19,7 @@ stepHandler.use((ctx) =>
   ctx.replyWithMarkdown('Press `Next` button or type /next')
 )
 
-const superWizard = new WizardScene(
+const superWizard = new Scenes.WizardScene(
   'super-wizard',
   async (ctx) => {
     await ctx.reply(
@@ -54,8 +46,8 @@ const superWizard = new WizardScene(
   }
 )
 
-const bot = new Telegraf<WizardContext>(token)
-const stage = new Stage<WizardContext>([superWizard], {
+const bot = new Telegraf<Scenes.WizardContext>(token)
+const stage = new Scenes.Stage<Scenes.WizardContext>([superWizard], {
   default: 'super-wizard',
 })
 bot.use(session())

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,20 +6,6 @@ export { Router } from './router'
 
 export * as Markup from './markup'
 
-export * from './session'
+export { session, MemorySessionStorage } from './session'
 
-export { Stage } from './stage'
-export {
-  SceneContext,
-  SceneSession,
-  default as SceneContextScene,
-  SceneSessionData,
-} from './scenes/context'
-export { BaseScene } from './scenes/base'
-export { WizardScene } from './scenes/wizard'
-export {
-  WizardContext,
-  WizardSession,
-  default as WizardContextWizard,
-  WizardSessionData,
-} from './scenes/wizard/context'
+export * as Scenes from './scenes'

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -1,0 +1,15 @@
+export { Stage } from './stage'
+export {
+  SceneContext,
+  SceneSession,
+  default as SceneContextScene,
+  SceneSessionData,
+} from './context'
+export { BaseScene } from './base'
+export { WizardScene } from './wizard'
+export {
+  WizardContext,
+  WizardSession,
+  default as WizardContextWizard,
+  WizardSessionData,
+} from './wizard/context'

--- a/src/scenes/stage.ts
+++ b/src/scenes/stage.ts
@@ -1,12 +1,12 @@
-import { isSessionContext, SessionContext } from './session'
+import { isSessionContext, SessionContext } from '../session'
 import SceneContextScene, {
   SceneContextSceneOptions,
   SceneSession,
   SceneSessionData,
-} from './scenes/context'
-import { BaseScene } from './scenes/base'
-import { Composer } from './composer'
-import { Context } from './context'
+} from './context'
+import { BaseScene } from './base'
+import { Composer } from '../composer'
+import { Context } from '../context'
 
 export class Stage<
   C extends SessionContext<SceneSession<D>> & {


### PR DESCRIPTION
# Description

Scenes-related stuff cannot be explained in isolation, so I decided to bundle them in a namespace to enhance discoverability.

The PR also removes unwanted `session` exports and fixes #705.

Before:
![obraz](https://user-images.githubusercontent.com/23058303/103672214-4d847f00-4f7c-11eb-9aaf-0c70f79496cb.png)

After:
![obraz](https://user-images.githubusercontent.com/23058303/103672243-58d7aa80-4f7c-11eb-9b89-3174ad35fa50.png)
![obraz](https://user-images.githubusercontent.com/23058303/103672259-5c6b3180-4f7c-11eb-8e3e-4ff2895b77cc.png)

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings