### PR TITLE
Restore 3.38 names in session module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export { Router } from './router'
 
 export * as Markup from './markup'
 
-export { session, MemorySessionStorage } from './session'
+export { session, MemorySessionStore } from './session'
 
 export * as Scenes from './scenes'

--- a/src/session.ts
+++ b/src/session.ts
@@ -50,9 +50,7 @@ export class MemorySessionStore<T> implements SessionStore<T> {
   private readonly ttl: number
   private readonly store = new Map<string, { session: T; expires: number }>()
 
-  constructor(ttl = Infinity) {
-    this.ttl = ttl * 1000
-  }
+  constructor(private readonly ttl = Infinity) {}
 
   async get(name: string): Promise<T | undefined> {
     const entry = this.store.get(name)

--- a/src/session.ts
+++ b/src/session.ts
@@ -47,7 +47,6 @@ async function defaultGetSessionKey(ctx: Context): Promise<string | undefined> {
 }
 
 export class MemorySessionStore<T> implements SessionStore<T> {
-  private readonly ttl: number
   private readonly store = new Map<string, { session: T; expires: number }>()
 
   constructor(private readonly ttl = Infinity) {}

--- a/src/session.ts
+++ b/src/session.ts
@@ -52,23 +52,23 @@ export class MemorySessionStore<T> implements SessionStore<T> {
 
   constructor(private readonly ttl = Infinity) {}
 
-  async get(name: string): Promise<T | undefined> {
+  get(name: string): T | undefined {
     const entry = this.store.get(name)
     if (entry == null) {
       return undefined
     } else if (entry.expires < Date.now()) {
-      await this.delete(name)
+      this.delete(name)
       return undefined
     }
     return entry.session
   }
 
-  async set(name: string, value: T): Promise<void> {
+  set(name: string, value: T): void {
     const now = Date.now()
     this.store.set(name, { session: value, expires: now + this.ttl })
   }
 
-  async delete(name: string): Promise<void> {
+  delete(name: string): void {
     this.store.delete(name)
   }
 }

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -242,9 +242,9 @@ test('should store session state with custom store', (t) => {
   const bot = createBot()
   const dummyStore = {}
   bot.use(session({
-    storage: {
-      getItem: (key) => new Promise((resolve) => setTimeout(resolve, 25, dummyStore[key])),
-      setItem: (key, value) => new Promise((resolve) => setTimeout(resolve, 25)).then(() => (dummyStore[key] = value))
+    store: {
+      get: (key) => new Promise((resolve) => setTimeout(resolve, 25, dummyStore[key])),
+      set: (key, value) => new Promise((resolve) => setTimeout(resolve, 25)).then(() => (dummyStore[key] = value))
     }
   }))
   bot.hears('calc', (ctx) => {


### PR DESCRIPTION
# Description

Renames most things in the session module to reduce the number of breaking changes from 3.38.0. Also fixes storage types in the sense that a synchronous storage is allowed, as it was before.

If I'm not mistaken, this is the last pull request before the 4.0 major release, also confer #1202.

## Type of change

Names of types and properties and config in `src/session.ts`.

# How Has This Been Tested?

`npm run clean && npm run checks`

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
