### PR TITLE
[fix] Make @types/node-fetch a production dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "types": "./typings/index.d.ts",
   "dependencies": {
+    "@types/node-fetch": "^2.5.7",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.1",
     "minimist": "^1.2.5",
@@ -63,7 +64,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/node": "^14.14.20",
-    "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "ava": "^3.15.0",


### PR DESCRIPTION
# Description

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

This line
https://github.com/telegraf/telegraf/blob/57f16c70901e3c73b9ab67933a926fedf7a2b11d/src/core/network/client.ts#L28 re-exports `RequestInit` from `@types/node-fetch`, causing a production dependency on the package.

Fixes the build error:

```text
packages/telegram build:w:
  node_modules/telegraf/typings/core/network/client.d.ts(3,29):
  error TS7016: Could not find a declaration file for module 'node-fetch'.
  'packages/telegram/node_modules/.pnpm/node-fetch@2.6.1/node_modules/node-fetch/lib/index.js' implicitly has an 'any' type.
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!--
CI typechecks, lints and runs the test suite.
If you did any extra manual tests, please describe them here.

**Test Configuration**:
* Node.js Version: v15.5.1
* Operating System: Debian 10.7 1 (4.19.0-13-amd64)
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
