### PR TITLE
Remove `MessageSubTypes`

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -4,6 +4,7 @@ import * as tt from './telegram-types'
 import { Middleware, MiddlewareFn, MiddlewareObj } from './middleware'
 import Context from './context'
 import { SnakeToCamelCase } from './core/helpers/string'
+import { UnionToIntersection } from './telegram-types'
 
 type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
@@ -14,11 +15,6 @@ type Triggers<C> = MaybeArray<
 type Predicate<T> = (t: T) => boolean
 type AsyncPredicate<T> = (t: T) => Promise<boolean>
 
-type UnionToIntersection<U> = (
-  U extends unknown ? (k: U) => void : never
-) extends (k: infer I) => void
-  ? I
-  : never
 type PropOr<T, P extends string, D> = T extends Record<P, infer V> ? V : D
 
 type MatchedMiddleware<

--- a/src/context.ts
+++ b/src/context.ts
@@ -22,40 +22,6 @@ export const UpdateTypes = [
   'poll_answer',
 ] as const
 
-export const MessageSubTypes = [
-  'voice',
-  'video_note',
-  'video',
-  'animation',
-  'venue',
-  'text',
-  'supergroup_chat_created',
-  'successful_payment',
-  'sticker',
-  'pinned_message',
-  'photo',
-  'new_chat_title',
-  'new_chat_photo',
-  'new_chat_members',
-  'migrate_to_chat_id',
-  'migrate_from_chat_id',
-  'location',
-  'left_chat_member',
-  'invoice',
-  'group_chat_created',
-  'game',
-  'dice',
-  'document',
-  'delete_chat_photo',
-  'contact',
-  'channel_chat_created',
-  'audio',
-  'connected_website',
-  'passport_data',
-  'poll',
-  'forward_date',
-] as const
-
 export class Context {
   readonly state: Record<string | symbol, any> = {}
 

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -1,7 +1,7 @@
 /** @format */
 
-import { Chat, Typegram } from 'typegram'
-import { MessageSubTypes, UpdateTypes } from './context'
+import { Chat, Message, Typegram } from 'typegram'
+import { UpdateTypes } from './context'
 
 // internal type provisions
 export * from 'typegram/callback'
@@ -137,7 +137,19 @@ export type ExtraVoice = MakeExtra<'sendVoice', 'voice'>
 
 // types used for inference of ctx object
 
+export type UnionToIntersection<U> = (
+  U extends unknown ? (k: U) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never
+
 /** Possible update types */
 export type UpdateType = typeof UpdateTypes[number]
+
 /** Possible message subtypes. Same as the properties on a message object */
-export type MessageSubType = typeof MessageSubTypes[number]
+export type MessageSubType =
+  | 'forward_date'
+  | Exclude<
+      keyof UnionToIntersection<Message>,
+      keyof Message.CaptionableMessage | 'entities' | 'media_group_id'
+    >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "tsBuildInfoFile": "typings/tsconfig.tsbuildinfo",
+    "noErrorTruncation": true,
     "forceConsistentCasingInFileNames": true
   },
   "typedocOptions": {


### PR DESCRIPTION
# Description

-1.3 kB install size
+1 maintainability
+1 readability: `"noErrorTruncation"` prevents VSCode from trimming type hints shown on hover

# How Has This Been Tested?

Verified that type remains the same, only adds previously missing `"proximity_alert_triggered"`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
