### PR TITLE
Set api root from environments

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -60,7 +60,7 @@ const DEFAULT_EXTENSIONS: Record<string, string | undefined> = {
 }
 
 const DEFAULT_OPTIONS: ApiClient.Options = {
-  apiRoot: 'https://api.telegram.org',
+  apiRoot: process.env.TELEGRAM_API_ROOT ?? 'https://api.telegram.org',
   webhookReply: true,
   agent: new https.Agent({
     keepAlive: true,


### PR DESCRIPTION
Sometimes maybe a user use Telegram instance multi times and for each of them user should set apiRoot 
if user forgot to set that field , bot uses official api and then maybe some updates not delivered to bot


## Type of change



- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


# How Has This Been Tested?


CI typechecks, lints and runs the test suite.



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
