### PR TITLE
feat(client): add `apiMode` option

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -344,7 +344,7 @@ class ApiClient {
           options.attachmentAgent
         )
       : await buildJSONConfig(payload)
-    const apiUrl = `${options.apiRoot}/${options.apiType}${token}/${method}`
+    const apiUrl = new URL(`${options.apiType}${token}/${method}`, options.apiRoot)
     config.agent = options.agent
     config.signal = signal
     config.timeout = 60_000 // 60s in ms

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -344,7 +344,10 @@ class ApiClient {
           options.attachmentAgent
         )
       : await buildJSONConfig(payload)
-    const apiUrl = new URL(`${options.apiType}${token}/${method}`, options.apiRoot)
+    const apiUrl = new URL(
+      `${options.apiType}${token}/${method}`,
+      options.apiRoot
+    )
     config.agent = options.agent
     config.signal = signal
     config.timeout = 60_000 // 60s in ms

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -28,6 +28,7 @@ const WEBHOOK_REPLY_METHOD_ALLOWLIST = new Set<keyof Telegram>([
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace ApiClient {
   export type Agent = http.Agent | ((parsedUrl: URL) => http.Agent) | undefined
+  export type Type = 'bot' | 'user'
   export interface Options {
     /**
      * Agent for communicating with the bot API.
@@ -41,6 +42,7 @@ namespace ApiClient {
      */
     attachmentAgent?: Agent
     apiRoot: string
+    apiType: Type
     webhookReply: boolean
   }
 
@@ -61,6 +63,7 @@ const DEFAULT_EXTENSIONS: Record<string, string | undefined> = {
 
 const DEFAULT_OPTIONS: ApiClient.Options = {
   apiRoot: 'https://api.telegram.org',
+  apiType: 'bot',
   webhookReply: true,
   agent: new https.Agent({
     keepAlive: true,
@@ -338,7 +341,7 @@ class ApiClient {
           options.attachmentAgent
         )
       : await buildJSONConfig(payload)
-    const apiUrl = `${options.apiRoot}/bot${token}/${method}`
+    const apiUrl = `${options.apiRoot}/${options.apiType}${token}/${method}`
     config.agent = options.agent
     config.signal = signal
     config.timeout = 60_000 // 60s in ms

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -45,7 +45,7 @@ namespace ApiClient {
      * @default 'bot'
      * @see https://github.com/tdlight-team/tdlight-telegram-bot-api#user-mode
      */
-    apiType: 'bot' | 'user'
+    apiMode: 'bot' | 'user'
     webhookReply: boolean
   }
 
@@ -66,7 +66,7 @@ const DEFAULT_EXTENSIONS: Record<string, string | undefined> = {
 
 const DEFAULT_OPTIONS: ApiClient.Options = {
   apiRoot: 'https://api.telegram.org',
-  apiType: 'bot',
+  apiMode: 'bot',
   webhookReply: true,
   agent: new https.Agent({
     keepAlive: true,
@@ -345,7 +345,7 @@ class ApiClient {
         )
       : await buildJSONConfig(payload)
     const apiUrl = new URL(
-      `${options.apiType}${token}/${method}`,
+      `${options.apiMode}${token}/${method}`,
       options.apiRoot
     )
     config.agent = options.agent

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -28,7 +28,6 @@ const WEBHOOK_REPLY_METHOD_ALLOWLIST = new Set<keyof Telegram>([
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace ApiClient {
   export type Agent = http.Agent | ((parsedUrl: URL) => http.Agent) | undefined
-  export type Type = 'bot' | 'user'
   export interface Options {
     /**
      * Agent for communicating with the bot API.
@@ -42,7 +41,11 @@ namespace ApiClient {
      */
     attachmentAgent?: Agent
     apiRoot: string
-    apiType: Type
+    /**
+     * @default 'bot'
+     * @see https://github.com/tdlight-team/tdlight-telegram-bot-api#user-mode
+     */
+    apiType: 'bot' | 'user'
     webhookReply: boolean
   }
 


### PR DESCRIPTION
# Description

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

Add feature to select `user` or `bot` type in api url to support `userbot`  from [TDLight](https://github.com/tdlight-team/tdlight-telegram-bot-api#user-mode)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Local bot start.
Run tests & lint.

**Test Configuration**:
* Node.js Version: v15.5.1
* Operating System: Windows 10

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
