### PR TITLE
Fix `startPayload` for commands with username

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -211,7 +211,8 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
   start(...fns: ReadonlyArray<Middleware<C & { startPayload: string }>>) {
     const handler = Composer.compose(fns)
     return this.command('start', (ctx, next) => {
-      const startPayload = ctx.message.text.substring(7)
+      const entity = ctx.message.entities![0]!
+      const startPayload = ctx.message.text.slice(entity.length + 1)
       return handler(Object.assign(ctx, { startPayload }), next)
     })
   }


### PR DESCRIPTION
# Description

`ctx.startPayload` would include the bots username if you used `/start@bot payload`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
