### PR TITLE
Explicitly define scene typings subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
   },
   "main": "lib/index.js",
   "exports": {
-    "import": "./lib/index.mjs",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js"
+    },
+    "./typings": "./lib/scenes/index.js"
   },
   "files": [
     "bin/*",


### PR DESCRIPTION
# Description

If we start the project with scenes, stage and custom context we get an error:
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './typings/scenes' is not defined by "exports" in /project/node_modules/telegraf/package.json

The code example is:
```
import { Context, Scenes, Telegraf } from "telegraf";
import { BaseScene, Stage } from "telegraf/typings/scenes";

interface CustomContext extends Context {
    scene: Scenes.SceneContextScene<CustomContext>;
}

const bot = new Telegraf<CustomContext>(process.env.TELEGRAM_TOKEN!);

const start = new BaseScene<CustomContext>("start-scene");
start.enter(async (ctx) => {
    await ctx.reply("Choose action");
});

const stage = new Stage<CustomContext>([start]);
bot.use(stage.middleware());

bot.start(async (ctx) => {
    await ctx.scene.enter("start-scene");
});
bot.launch();
```
So maybe the solution is to explicitly define exporting subpath for scenes typings.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* Node.js Version: 14.15.3
* Operating System: Ubuntu 20.04.1 LTS
* Telegraf: 4.0.2

With this changes project with the Telegraf library starts without errors and works as expected.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
