### PR TITLE
hotfix(client): include base url

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -345,7 +345,7 @@ class ApiClient {
         )
       : await buildJSONConfig(payload)
     const apiUrl = new URL(
-      `${options.apiMode}${token}/${method}`,
+      `/${options.apiMode}${token}/${method}`,
       options.apiRoot
     )
     config.agent = options.agent

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -39,7 +39,7 @@ class Telegram extends ApiClient {
     }
 
     return new URL(
-      `file/${this.options.apiMode}${this.token}/${fileId.file_path!}`,
+      `/file/${this.options.apiMode}${this.token}/${fileId.file_path!}`,
       this.options.apiRoot
     )
   }


### PR DESCRIPTION
# Description

With current `apiUrl` it transforms to `botTOKEN/getMe` and not include base from `URL` constructor.
And we got `Only HTTP(S) protocols are supported` error from `fetch` url validation.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!--
CI typechecks, lints and runs the test suite.
If you did any extra manual tests, please describe them here.

**Test Configuration**:
* Node.js Version:
* Operating System:
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
