### PR TITLE
Redact secret part of token from error messages

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -275,6 +275,11 @@ async function answerToWebhook(
   return true
 }
 
+function redactToken(error: Error): never {
+  error.message = error.message.replace(/:\w+/, ':[REDACTED]')
+  throw error
+}
+
 type Response = http.ServerResponse
 class ApiClient {
   readonly options: ApiClient.Options
@@ -350,7 +355,7 @@ class ApiClient {
     )
     config.agent = options.agent
     config.signal = signal
-    const res = await fetch(apiUrl, config)
+    const res = await fetch(apiUrl, config).catch(redactToken)
     const data = await res.json()
     if (!data.ok) {
       debug('API call failed', data)


### PR DESCRIPTION
https://github.com/telegraf/telegraf/issues/1023#issuecomment-706696323

# How Has This Been Tested?

`FetchError: request to https://api.telegram.org/bot204305089:[REDACTED]/getMe failed, reason: getaddrinfo ENOTFOUND api.telegram.org`

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
