### PR TITLE
Change Telegram extra to be optional when not needed

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -734,7 +734,7 @@ class Telegram extends ApiClient {
     messageId: number | undefined,
     inlineMessageId: string | undefined,
     caption: string | undefined,
-    extra: tt.ExtraEditMessageCaption = {}
+    extra?: tt.ExtraEditMessageCaption
   ) {
     return this.callApi('editMessageCaption', {
       caption,
@@ -762,7 +762,7 @@ class Telegram extends ApiClient {
     messageId: number | undefined,
     inlineMessageId: string | undefined,
     media: tt.InputMedia,
-    extra: tt.ExtraEditMessageMedia = {}
+    extra?: tt.ExtraEditMessageMedia
   ) {
     return this.callApi('editMessageMedia', {
       chat_id: chatId,

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -194,7 +194,7 @@ class Telegram extends ApiClient {
     longitude: number,
     title: string,
     address: string,
-    extra: tt.ExtraVenue
+    extra?: tt.ExtraVenue
   ) {
     return this.callApi('sendVenue', {
       latitude,
@@ -225,7 +225,7 @@ class Telegram extends ApiClient {
     chatId: number | string,
     phoneNumber: string,
     firstName: string,
-    extra: tt.ExtraContact
+    extra?: tt.ExtraContact
   ) {
     return this.callApi('sendContact', {
       chat_id: chatId,
@@ -387,7 +387,7 @@ class Telegram extends ApiClient {
     chatId: number | string,
     question: string,
     options: readonly string[],
-    extra: tt.ExtraPoll
+    extra?: tt.ExtraPoll
   ) {
     return this.callApi('sendPoll', {
       chat_id: chatId,
@@ -426,7 +426,7 @@ class Telegram extends ApiClient {
   stopPoll(
     chatId: number | string,
     messageId: number,
-    extra: tt.ExtraStopPoll
+    extra?: tt.ExtraStopPoll
   ) {
     return this.callApi('stopPoll', {
       chat_id: chatId,


### PR DESCRIPTION
# Description

Extra options for Telegram methods can be optional when they are not needed.

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Checking on the official Telegram Bot API documentation which optionals are really needed or not.
Also `replyWithVenue` worked without on 3.38 and works now with just supplying `{}` as extra.

<!--
CI typechecks, lints and runs the test suite.
If you did any extra manual tests, please describe them here.

**Test Configuration**:
* Node.js Version:
* Operating System:
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
