### PR TITLE
Allow to import `Telegram` class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { Composer } from './composer'
 export { Middleware, MiddlewareFn } from './middleware'
 export { Router } from './router'
 export { TelegramError } from './core/network/error'
-export { default as Telegram } from './telegram'
+export { Telegram } from './telegram'
 
 export * as Markup from './markup'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { Composer } from './composer'
 export { Middleware, MiddlewareFn } from './middleware'
 export { Router } from './router'
 export { TelegramError } from './core/network/error'
+export { default as Telegram } from './telegram'
 
 export * as Markup from './markup'
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -3,7 +3,7 @@ import ApiClient from './core/network/client'
 import { isAbsolute } from 'path'
 import { URL } from 'url'
 
-class Telegram extends ApiClient {
+export class Telegram extends ApiClient {
   /**
    * Get basic information about the bot
    */


### PR DESCRIPTION
# Description

- export `Telegram` class because it usefull for mocking API in tests. See #1362

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested by building project and importing class in typescript project

```typescript
import {  Telegram } from 'telegraf'
```
**Test Configuration**:
* Node.js Version: 12.0, 15.0
* Operating System: MacOS, Windows 10

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
