### PR TITLE
Narrow more getters in `GuardedContext` to future-proof it

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -39,7 +39,11 @@ type Getter<U extends tt.Update, P extends string> = PropOr<
 >
 
 /**
- * Narrows down `Context['update']` and some derived properties.
+ * Narrows down `C['update']` (and derived getters)
+ * to specific update type `U`.
+ *
+ * Used by [[`Composer`]],
+ * possibly useful for splitting a bot into multiple files.
  */
 type GuardedContext<C extends Context, U extends tt.Update> = C &
   {

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -31,7 +31,7 @@ type MatchedContext<
   T extends tt.UpdateType | tt.MessageSubType
 > = GuardedContext<C, MountMap[T]>
 
-type UpdateTypes<U> = Exclude<UnionKeys<U>, keyof tt.Update>
+type UpdateTypes<U extends tt.Update> = Exclude<UnionKeys<U>, keyof tt.Update>
 type Getter<U extends tt.Update, P extends string> = PropOr<
   GetMessageFromAnySource<U>,
   P,

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -34,6 +34,11 @@ type MatchedContext<
 
 type UpdateIntersection = UnionToIntersection<tt.Update>
 type UpdateTypes<U> = Exclude<UnionKeys<U>, keyof tt.Update>
+type Getter<U extends tt.Update, P extends string> = PropOr<
+  UpdateIntersection[UpdateTypes<U>],
+  P,
+  undefined
+>
 
 /**
  * Narrows down `Context['update']` and some derived properties.
@@ -44,13 +49,9 @@ type GuardedContext<C extends Context, U extends tt.Update> = C &
   } & {
     update: U
     updateType: keyof UnionToIntersection<U>
-    chat: PropOr<UpdateIntersection[UpdateTypes<U>], 'chat', undefined>
-    from: PropOr<UpdateIntersection[UpdateTypes<U>], 'from', undefined>
-    sender_chat: PropOr<
-      UpdateIntersection[UpdateTypes<U>],
-      'sender_chat',
-      undefined
-    >
+    sender_chat: Getter<U, 'sender_chat'>
+    from: Getter<U, 'from'>
+    chat: Getter<U, 'chat'>
   }
 /**
  * Maps `Composer.mount`'s `updateType` to a type

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,11 +1,10 @@
 /** @format */
 
 import * as tt from './telegram-types'
+import Context, { GetMessageFromAnySource } from './context'
 import { Middleware, MiddlewareFn, MiddlewareObj } from './middleware'
 import { PropOr, UnionKeys } from './deunionize'
-import Context from './context'
 import { SnakeToCamelCase } from './core/helpers/string'
-import { UnionToIntersection } from './telegram-types'
 
 type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
@@ -32,10 +31,9 @@ type MatchedContext<
   T extends tt.UpdateType | tt.MessageSubType
 > = GuardedContext<C, MountMap[T]>
 
-type UpdateIntersection = UnionToIntersection<tt.Update>
 type UpdateTypes<U> = Exclude<UnionKeys<U>, keyof tt.Update>
 type Getter<U extends tt.Update, P extends string> = PropOr<
-  UpdateIntersection[UpdateTypes<U>],
+  GetMessageFromAnySource<U>,
   P,
   undefined
 >
@@ -48,8 +46,8 @@ type GuardedContext<C extends Context, U extends tt.Update> = C &
     [P in tt.UpdateType as SnakeToCamelCase<P>]: PropOr<U, P, undefined>
   } & {
     update: U
-    updateType: keyof UnionToIntersection<U>
-    sender_chat: Getter<U, 'sender_chat'>
+    updateType: UpdateTypes<U>
+    senderChat: Getter<U, 'sender_chat'>
     from: Getter<U, 'from'>
     chat: Getter<U, 'chat'>
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import * as tt from './telegram-types'
 import ApiClient from './core/network/client'
+import { PropOr } from './deunionize'
 import Telegram from './telegram'
 
 type Tail<T> = T extends [unknown, ...infer U] ? U : never
@@ -563,6 +564,16 @@ export class Context {
 
 export default Context
 
+export type GetMessageFromAnySource<
+  U extends tt.Update
+> = U extends tt.Update.CallbackQueryUpdate
+  ? U['callback_query']['message']
+  :
+      | PropOr<U, 'message', never>
+      | PropOr<U, 'edited_message', never>
+      | PropOr<U, 'channel_post', never>
+      | PropOr<U, 'edited_channel_post', never>
+// KEEP THESE IN SYNC!
 function getMessageFromAnySource(ctx: Context) {
   return (
     ctx.message ??

--- a/src/deunionize.ts
+++ b/src/deunionize.ts
@@ -1,5 +1,5 @@
 export type PropOr<
-  T extends object,
+  T,
   P extends string | symbol | number,
   D
 > = T extends Partial<Record<P, unknown>> ? T[P] : D

--- a/src/deunionize.ts
+++ b/src/deunionize.ts
@@ -1,5 +1,5 @@
 export type PropOr<
-  T,
+  T extends object | undefined,
   P extends string | symbol | number,
   D
 > = T extends Partial<Record<P, unknown>> ? T[P] : D


### PR DESCRIPTION
# Description

Before exposing `GuardedContext` (#1306), I decided to future-proof it. What better way to do that than to add a difficult feature and fix what breaks? So I narrowed `ctx.from`, `ctx.chat` and `ctx.senderChat`, and now I need someone to review this.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
