### PR TITLE
[Proposal] Add critical section for session without API changes

### DIFF
--- a/src/core/helpers/lock.ts
+++ b/src/core/helpers/lock.ts
@@ -1,0 +1,41 @@
+export class Lock {
+  private readonly queuedLocks: Map<string, Function[]>
+
+  constructor() {
+    this.queuedLocks = new Map<string, Function[]>()
+  }
+
+  async acquire(key: string) {
+    const queue = this.queuedLocks.get(key)
+    console.log(`acquire: ${JSON.stringify(queue)}`)
+    if (!queue) {
+      this.queuedLocks.set(key, [])
+      return true
+    }
+
+    const task = new Promise((resolve) => {
+      queue.push(resolve)
+    })
+
+    return await task
+  }
+
+  async release(key: string) {
+    const queue = this.queuedLocks.get(key)
+    console.log(`release: ${JSON.stringify(queue)}`)
+    if (!queue) {
+      console.warn('Nothing to release')
+      return false
+    }
+
+    const nextLock = queue[0]
+    if (!nextLock) {
+      this.queuedLocks.delete(key)
+      return true
+    }
+
+    this.queuedLocks.set(key, queue.slice(1))
+    nextLock(true)
+    return true
+  }
+}

--- a/src/core/helpers/lock.ts
+++ b/src/core/helpers/lock.ts
@@ -7,7 +7,6 @@ export class Lock {
 
   async acquire(key: string) {
     const queue = this.queuedLocks.get(key)
-    console.log(`acquire: ${JSON.stringify(queue)}`)
     if (!queue) {
       this.queuedLocks.set(key, [])
       return true
@@ -22,7 +21,6 @@ export class Lock {
 
   async release(key: string) {
     const queue = this.queuedLocks.get(key)
-    console.log(`release: ${JSON.stringify(queue)}`)
     if (!queue) {
       console.warn('Nothing to release')
       return false


### PR DESCRIPTION
# Description
This is what I had in mind when I was talking about mutex for https://github.com/telegraf/telegraf/issues/1372. Even though Javascript is single-threaded, it can still benefit from locks and critical sections for the purpose of ordering async operations. This change will add a makeshift synchronized locking mechanism to session.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!--
CI typechecks, lints and runs the test suite.
If you did any extra manual tests, please describe them here.

**Test Configuration**:
* Node.js Version: 15.3.0
* Operating System: MacOS Mojave
-->

Minimal code example described in https://github.com/telegraf/telegraf/issues/1372.

Results:
```
acquire: undefined
acquire: []
acquire: [null]
acquire: [null,null]
  test Defaulting session to { update_id: 276771606 } +0ms
release: [null,null,null]
  test Session already set to { update_id: 276771606 } +2ms
release: [null,null]
  test Session already set to { update_id: 276771606 } +1ms
release: [null]
  test Session already set to { update_id: 276771606 } +0ms
release: []
acquire: undefined
  test Session already set to { update_id: 276771606 } +51s
release: []
```

Note: Logs containing `acquire` and `release` to be removed before proposal acceptance.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
