### PR TITLE
Fix type of `ctx.from`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4170,9 +4170,9 @@
       "dev": true
     },
     "typegram": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.1.4.tgz",
-      "integrity": "sha512-AsYxLLynwBgeUJNU+3oSYNPSB3bwb/uyzrEPvrPwC0HXCYhW+otNV5q4T8Sb43SQSAP71hWC8EzBgDtlGGBx0A=="
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.1.10.tgz",
+      "integrity": "sha512-VfsuVP4uqk9yllRpaGp9yFpzvLKXghFCOSc3TVi+fy1IL2Bi4z2gJ9rMgVSSug4pWQP8Ui7Isvl14yYV8VEWaQ=="
     },
     "typescript": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-fetch": "^2.6.1",
     "p-timeout": "^4.1.0",
     "sandwich-stream": "^2.0.2",
-    "typegram": "^3.1.4"
+    "typegram": "^3.1.10"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,9 +1,9 @@
 /** @format */
 
 import * as tt from './telegram-types'
-import Context, { GetMessageFromAnySource } from './context'
+import Context, { GetMessageFromAnySource, UpdateTypes } from './context'
 import { Middleware, MiddlewareFn, MiddlewareObj } from './middleware'
-import { PropOr, UnionKeys } from './deunionize'
+import { PropOr } from './deunionize'
 import { SnakeToCamelCase } from './core/helpers/string'
 
 type MaybeArray<T> = T | T[]
@@ -31,7 +31,6 @@ type MatchedContext<
   T extends tt.UpdateType | tt.MessageSubType
 > = NarrowedContext<C, MountMap[T]>
 
-type UpdateTypes<U extends tt.Update> = Exclude<UnionKeys<U>, keyof tt.Update>
 type Getter<U extends tt.Update, P extends string> = PropOr<
   GetMessageFromAnySource<U>,
   P,

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,7 +1,7 @@
 /** @format */
 
 import * as tt from './telegram-types'
-import Context, { GetMessageFromAnySource, UpdateTypes } from './context'
+import Context, { GetUpdateContent, UpdateTypes } from './context'
 import { Middleware, MiddlewareFn, MiddlewareObj } from './middleware'
 import { PropOr } from './deunionize'
 import { SnakeToCamelCase } from './core/helpers/string'
@@ -32,7 +32,7 @@ type MatchedContext<
 > = NarrowedContext<C, MountMap[T]>
 
 type Getter<U extends tt.Update, P extends string> = PropOr<
-  GetMessageFromAnySource<U>,
+  GetUpdateContent<U>,
   P,
   undefined
 >

--- a/src/context.ts
+++ b/src/context.ts
@@ -555,8 +555,7 @@ export type UpdateTypes<U extends tt.Update> = Extract<
   tt.UpdateType
 >
 
-// TODO rename
-export type GetMessageFromAnySource<
+export type GetUpdateContent<
   U extends tt.Update
 > = U extends tt.Update.CallbackQueryUpdate
   ? U['callback_query']['message']

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,27 +1,13 @@
 import * as tt from './telegram-types'
 import ApiClient from './core/network/client'
-import { PropOr } from './deunionize'
 import Telegram from './telegram'
+import { UnionKeys } from './deunionize'
 
 type Tail<T> = T extends [unknown, ...infer U] ? U : never
 
 type Shorthand<FName extends Exclude<keyof Telegram, keyof ApiClient>> = Tail<
   Parameters<Telegram[FName]>
 >
-
-export const UpdateTypes = [
-  'callback_query',
-  'channel_post',
-  'chosen_inline_result',
-  'edited_channel_post',
-  'edited_message',
-  'inline_query',
-  'message',
-  'pre_checkout_query',
-  'shipping_query',
-  'poll',
-  'poll_answer',
-] as const
 
 export class Context {
   readonly state: Record<string | symbol, any> = {}
@@ -33,7 +19,7 @@ export class Context {
   ) {}
 
   get updateType() {
-    return UpdateTypes.find((key) => key in this.update)
+    return tt.updateTypes.find((key) => key in this.update)
   }
 
   get me() {
@@ -564,16 +550,18 @@ export class Context {
 
 export default Context
 
+export type UpdateTypes<U extends tt.Update> = Extract<
+  UnionKeys<U>,
+  tt.UpdateType
+>
+
+// TODO rename
 export type GetMessageFromAnySource<
   U extends tt.Update
 > = U extends tt.Update.CallbackQueryUpdate
   ? U['callback_query']['message']
-  :
-      | PropOr<U, 'message', never>
-      | PropOr<U, 'edited_message', never>
-      | PropOr<U, 'channel_post', never>
-      | PropOr<U, 'edited_channel_post', never>
-// KEEP THESE IN SYNC!
+  : U[UpdateTypes<U>]
+
 function getMessageFromAnySource(ctx: Context) {
   return (
     ctx.message ??

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -1,7 +1,6 @@
 /** @format */
 
 import { Chat, Message, Typegram } from 'typegram'
-import { UpdateTypes } from './context'
 
 // internal type provisions
 export * from 'typegram/callback'
@@ -143,8 +142,22 @@ export type UnionToIntersection<U> = (
   ? I
   : never
 
+export const updateTypes = [
+  'callback_query',
+  'channel_post',
+  'chosen_inline_result',
+  'edited_channel_post',
+  'edited_message',
+  'inline_query',
+  'message',
+  'pre_checkout_query',
+  'shipping_query',
+  'poll',
+  'poll_answer',
+] as const
+
 /** Possible update types */
-export type UpdateType = typeof UpdateTypes[number]
+export type UpdateType = typeof updateTypes[number]
 
 /** Possible message subtypes. Same as the properties on a message object */
 export type MessageSubType =


### PR DESCRIPTION
@EdJoPaTo, what should I rename `GetMessageFromAnySource` to? Also, it'd be nice if you checked it actually works: `npm install --no-save telegraf/telegraf#8ad3d7d`

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
