### PR TITLE
Make default `hookPath` deterministic

### DIFF
--- a/docs/examples/express-webhook-bot.ts
+++ b/docs/examples/express-webhook-bot.ts
@@ -13,14 +13,16 @@ const bot = new Telegraf(token)
 // Set the bot response
 bot.on('text', (ctx) => ctx.replyWithHTML('<b>Hello</b>'))
 
+const secretPath = `/telegraf/${bot.secretPathComponent()}`
+
 // Set telegram webhook
 // npm install -g localtunnel && lt --port 3000
-bot.telegram.setWebhook('https://----.localtunnel.me/secret-path')
+bot.telegram.setWebhook(`https://----.localtunnel.me${secretPath}`)
 
 const app = express()
 app.get('/', (req: Request, res: Response) => res.send('Hello World!'))
 // Set the bot API endpoint
-app.use(bot.webhookCallback('/secret-path'))
+app.use(bot.webhookCallback(secretPath))
 app.listen(3000, () => {
   console.log('Example app listening on port 3000!')
 })

--- a/docs/examples/fastify-webhook-bot.js
+++ b/docs/examples/fastify-webhook-bot.js
@@ -6,7 +6,6 @@ const telegrafPlugin = require('fastify-telegraf')
 
 const { BOT_TOKEN, WEBHOOK_URL } = process.env
 const PORT = process.env.PORT || 3000
-const SECRET_PATH = '/my-secret-path'
 
 if (!WEBHOOK_URL) throw new Error('"WEBHOOK_URL" env var is required!')
 if (!BOT_TOKEN) throw new Error('"BOT_TOKEN" env var is required!')
@@ -14,6 +13,7 @@ if (!BOT_TOKEN) throw new Error('"BOT_TOKEN" env var is required!')
 const bot = new Telegraf(BOT_TOKEN)
 const app = fastify()
 
+const SECRET_PATH = `/telegraf/${bot.secretPathComponent()}`
 app.register(telegrafPlugin, { bot, path: SECRET_PATH })
 
 bot.on('text', (ctx) => ctx.reply('Hello'))

--- a/docs/examples/koa-webhook-bot.js
+++ b/docs/examples/koa-webhook-bot.js
@@ -3,6 +3,7 @@ const { Telegraf } = require('telegraf')
 const Koa = require('koa')
 // @ts-expect-error not a dependency of Telegraf
 const koaBody = require('koa-body')
+const safeCompare = require('safe-compare')
 
 const token = process.env.BOT_TOKEN
 if (token === undefined) {
@@ -16,15 +17,17 @@ const bot = new Telegraf(token)
 bot.command('image', (ctx) => ctx.replyWithPhoto({ url: 'https://picsum.photos/200/300/?random' }))
 bot.on('text', (ctx) => ctx.reply('Hello'))
 
+const secretPath = `/telegraf/${bot.secretPathComponent()}`
+
 // Set telegram webhook
 // npm install -g localtunnel && lt --port 3000
-bot.telegram.setWebhook('https://-----.localtunnel.me/secret-path')
+bot.telegram.setWebhook(`https://-----.localtunnel.me${secretPath}`)
 
 const app = new Koa()
 app.use(koaBody())
 // @ts-ignore
 app.use(async (ctx, next) => {
-  if (ctx.url === '/secret-path') {
+  if (safeCompare(secretPath, ctx.url)) {
     await bot.handleUpdate(ctx.request.body)
     ctx.status = 200
     return

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -46,7 +46,10 @@ export namespace Telegraf {
       /** Public domain for webhook. If domain is not specified, hookPath should contain a domain name as well (not only path component). */
       domain?: string
 
-      /** Webhook url path; will be automatically generated if not specified */
+      /**
+       * Webhook url path.
+       * @deprecated Safely derived if not specified.
+       * */
       hookPath?: string
 
       host?: string
@@ -149,6 +152,14 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     return this
   }
 
+  secretPathComponent() {
+    return crypto
+      .createHash('sha3-256')
+      .update(this.token)
+      .update(process.version)
+      .digest('hex')
+  }
+
   /**
    * @see https://github.com/telegraf/telegraf/discussions/1344#discussioncomment-335700
    */
@@ -175,8 +186,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
       domain = new URL(domain).host
     }
     const hookPath =
-      config.webhook.hookPath ??
-      `/telegraf/${crypto.randomBytes(32).toString('hex')}`
+      config.webhook.hookPath ?? `/telegraf/${this.secretPathComponent()}`
     const { port, host, tlsOptions, cb } = config.webhook
     this.startWebhook(hookPath, tlsOptions, port, host, cb)
     if (!domain) {

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -46,10 +46,7 @@ export namespace Telegraf {
       /** Public domain for webhook. If domain is not specified, hookPath should contain a domain name as well (not only path component). */
       domain?: string
 
-      /**
-       * Webhook url path.
-       * @deprecated Safely derived if not specified.
-       * */
+      /** Webhook url path; will be automatically generated if not specified */
       hookPath?: string
 
       host?: string
@@ -156,7 +153,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     return crypto
       .createHash('sha3-256')
       .update(this.token)
-      .update(process.version)
+      .update(process.version) // salt
       .digest('hex')
   }
 

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -156,3 +156,11 @@ test('should respect webhookReply runtime change (per request)', async (t) => {
   t.true(res.writableEnded)
   t.is(res.body, undefined)
 })
+
+test('should deterministically generate `secretPathComponent`', (t) => {
+  const foo = createBot('foo')
+  const bar = createBot('bar')
+  t.deepEqual(foo.secretPathComponent(), foo.secretPathComponent())
+  t.deepEqual(bar.secretPathComponent(), bar.secretPathComponent())
+  t.notDeepEqual(foo.secretPathComponent(), bar.secretPathComponent())
+})


### PR DESCRIPTION
Should prevent 403s in cluster or when woken up on Heroku:

![obraz](https://user-images.githubusercontent.com/23058303/109394999-51a09d80-792a-11eb-900b-d2c88d32be0b.png)

cc @ioscars

https://github.com/telegraf/telegraf/blob/develop/README.md#webhooks needs rewriting after this.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
