### PR TITLE
Fix `ctx.from` and `ctx.chat` for Bot API 5.1

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -97,10 +97,10 @@ export class Context {
 
   get chat() {
     return (
-      this.chatMember?.chat ??
-      this.myChatMember?.chat ??
-      getMessageFromAnySource(this)?.chat
-    )
+      this.chatMember ??
+      this.myChatMember ??
+      getMessageFromAnySource(this)
+    )?.chat
   }
 
   get senderChat() {

--- a/src/context.ts
+++ b/src/context.ts
@@ -110,6 +110,8 @@ export class Context {
       this.shippingQuery ??
       this.preCheckoutQuery ??
       this.chosenInlineResult ??
+      this.chatMember ??
+      this.myChatMember ??
       getMessageFromAnySource(this)
     )?.from
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -96,7 +96,11 @@ export class Context {
   }
 
   get chat() {
-    return getMessageFromAnySource(this)?.chat
+    return (
+      this.chatMember?.chat ??
+      this.myChatMember?.chat ??
+      getMessageFromAnySource(this)?.chat
+    )
   }
 
   get senderChat() {


### PR DESCRIPTION
# Description

New Bot API 5.1 update types [include](https://core.telegram.org/bots/api#chatmemberupdated) `from` field
But telegraf@4.2.0  `ctx.from` getter doesn't take it into account

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
