### PR TITLE
Allow narrowing via `Message::hasOwnProperty`

### DIFF
--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -172,3 +172,14 @@ export type MessageSubType =
       UnionKeys<Message>,
       keyof Message.CaptionableMessage | 'entities' | 'media_group_id'
     >
+
+declare module 'typegram/message' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Message {
+    interface ServiceMessage {
+      hasOwnProperty: <T extends MessageSubType>(
+        prop: T
+      ) => this is Extract<Message, Partial<Record<T, unknown>>>
+    }
+  }
+}


### PR DESCRIPTION
# Description

> `ctx.message?.hasOwnProperty("text")` vs `ctx.message !== undefined && "text" in ctx.message`

# How Has This Been Tested?

Manually.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
