### PR TITLE
Deunionize some `Context` getters by default

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -40,55 +40,61 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   }
 
   get message() {
-    return this.update.message as PropOr<U, 'message'>
+    return this.update.message as Deunionize<PropOr<U, 'message'>>
   }
 
   get editedMessage() {
-    return this.update.edited_message as PropOr<U, 'edited_message'>
+    return this.update.edited_message as Deunionize<PropOr<U, 'edited_message'>>
   }
 
   get inlineQuery() {
-    return this.update.inline_query as PropOr<U, 'inline_query'>
+    return this.update.inline_query as Deunionize<PropOr<U, 'inline_query'>>
   }
 
   get shippingQuery() {
-    return this.update.shipping_query as PropOr<U, 'shipping_query'>
+    return this.update.shipping_query as Deunionize<PropOr<U, 'shipping_query'>>
   }
 
   get preCheckoutQuery() {
-    return this.update.pre_checkout_query as PropOr<U, 'pre_checkout_query'>
+    return this.update.pre_checkout_query as Deunionize<
+      PropOr<U, 'pre_checkout_query'>
+    >
   }
 
   get chosenInlineResult() {
-    return this.update.chosen_inline_result as PropOr<U, 'chosen_inline_result'>
+    return this.update.chosen_inline_result as Deunionize<
+      PropOr<U, 'chosen_inline_result'>
+    >
   }
 
   get channelPost() {
-    return this.update.channel_post as PropOr<U, 'channel_post'>
+    return this.update.channel_post as Deunionize<PropOr<U, 'channel_post'>>
   }
 
   get editedChannelPost() {
-    return this.update.edited_channel_post as PropOr<U, 'edited_channel_post'>
+    return this.update.edited_channel_post as Deunionize<
+      PropOr<U, 'edited_channel_post'>
+    >
   }
 
   get callbackQuery() {
-    return this.update.callback_query as PropOr<U, 'callback_query'>
+    return this.update.callback_query as Deunionize<PropOr<U, 'callback_query'>>
   }
 
   get poll() {
-    return this.update.poll as PropOr<U, 'poll'>
+    return this.update.poll as Deunionize<PropOr<U, 'poll'>>
   }
 
   get pollAnswer() {
-    return this.update.poll_answer as PropOr<U, 'poll_answer'>
+    return this.update.poll_answer as Deunionize<PropOr<U, 'poll_answer'>>
   }
 
   get myChatMember() {
-    return this.update.my_chat_member as PropOr<U, 'my_chat_member'>
+    return this.update.my_chat_member as Deunionize<PropOr<U, 'my_chat_member'>>
   }
 
   get chatMember() {
-    return this.update.chat_member as PropOr<U, 'chat_member'>
+    return this.update.chat_member as Deunionize<PropOr<U, 'chat_member'>>
   }
 
   get chat(): Getter<U, 'chat'> {

--- a/src/deunionize.ts
+++ b/src/deunionize.ts
@@ -20,6 +20,7 @@ export type Deunionize<
  * Expose properties from all union variants.
  * @see https://github.com/telegraf/telegraf/issues/1388#issuecomment-791573609
  * @see https://millsp.github.io/ts-toolbelt/modules/union_strict.html
+ * @deprecated
  */
 export function deunionize<T extends object | undefined>(t: T) {
   return t as Deunionize<T>


### PR DESCRIPTION
# Description

Advantages:

+ Fixes #1388, fixes #1423,
+ Allows narrowing via `ctx.message.foo !== undefined`.

Disadvantages:

- Slows down TypeScript a bit,
- Narrowing doesn't remove `?: undefined` properties (https://github.com/microsoft/TypeScript/issues/43117),
- **BREAKING CHANGE**: `in` no longer narrows.


Try it out! `npm install telegraf/telegraf#deunionize`

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-->

# How Has This Been Tested?

Manually.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
