### PR TITLE
Delete useless check

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -188,7 +188,6 @@ async function attachFormValue(
     })
   }
   if (
-    value &&
     typeof value === 'object' &&
     hasProp(value, 'media') &&
     hasProp(value, 'type') &&


### PR DESCRIPTION
# Description

This PR removes a useless check in the `attachFormValue()` function.

```typescript
async function attachFormValue(
// ...
) {
  if (value == null) {
    return
  }

// ...

  if (
    value &&
    typeof value === 'object' &&
    hasProp(value, 'media') &&
    hasProp(value, 'type') &&
    typeof value.media !== 'undefined' &&
    typeof value.type !== 'undefined'
  ) {
```

The `if (value)` check was meant to ensure that value is not `null` (because `typeof null === 'object'`) but that condition is already checked.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with LGTM static code analysis (it reported this issue).

**Test Configuration**:
* Node.js Version: 14.17.0
* Operating System: Ubuntu 21.04

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation - N/A
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A
