### PR TITLE
Fix url as mentioned in #1468

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question (via Telegram groups)
-    url: https://github.com/telegraf/telegraf/blob/develop/docs/README.md#resources
+    url: https://github.com/telegraf/telegraf#resources
     about: Ask and answer questions about Telegraf
   - name: Question (via GitHub Discussions)
     url: https://github.com/telegraf/telegraf/discussions/categories/q-a


### PR DESCRIPTION
# Description

Fixed a misleading url for telegram chats in issue creating as mentioned in #1468 .

## Type of change

<!--
Please delete options that are not relevant.

- Documentation (typos, code examples or any documentation update)
- Bug fix (non-breaking change which fixes an issue)
-->

# How Has This Been Tested?

No tests, the link just works :)

# Checklist:

- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
