### PR TITLE
fix(telegram): allow string as chatID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
         "sandwich-stream": "^2.0.2",
-        "typegram": "^3.4.0"
+        "typegram": "^3.4.2"
       },
       "bin": {
         "telegraf": "bin/telegraf"
@@ -5068,9 +5068,9 @@
       }
     },
     "node_modules/typegram": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.4.0.tgz",
-      "integrity": "sha512-GUE1LV3LJruTThJaUBUvTnaEpTswFhuxhEx9LaVLIA6WRw9CdPQmb87OIA0rCvoMSPBC8gZiHrrPqX9VJGDXwQ=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.4.2.tgz",
+      "integrity": "sha512-Z+FaPrD+oyzvchLZHmfyz55MuPhJ51tYm6i+gbeZ0W8Yr4LLWQfI0mBlR2v08PzjHuRx26bmZBEM30jSrGbfbg=="
     },
     "node_modules/typescript": {
       "version": "4.2.3",
@@ -9505,9 +9505,9 @@
       "dev": true
     },
     "typegram": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.4.0.tgz",
-      "integrity": "sha512-GUE1LV3LJruTThJaUBUvTnaEpTswFhuxhEx9LaVLIA6WRw9CdPQmb87OIA0rCvoMSPBC8gZiHrrPqX9VJGDXwQ=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.4.2.tgz",
+      "integrity": "sha512-Z+FaPrD+oyzvchLZHmfyz55MuPhJ51tYm6i+gbeZ0W8Yr4LLWQfI0mBlR2v08PzjHuRx26bmZBEM30jSrGbfbg=="
     },
     "typescript": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "p-timeout": "^4.1.0",
     "safe-compare": "^1.1.4",
     "sandwich-stream": "^2.0.2",
-    "typegram": "^3.4.0"
+    "typegram": "^3.4.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -832,7 +832,7 @@ export class Telegram extends ApiClient {
   }
 
   editMessageLiveLocation(
-    chatId: number | undefined,
+    chatId: number | string | undefined,
     messageId: number | undefined,
     inlineMessageId: string | undefined,
     latitude: number,

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -211,7 +211,7 @@ export class Telegram extends ApiClient {
    * @param chatId Unique identifier for the target private chat
    */
   sendInvoice(
-    chatId: number,
+    chatId: number | string,
     invoice: tt.NewInvoiceParameters,
     extra?: tt.ExtraInvoice
   ) {


### PR DESCRIPTION
# Description

[sendInvoice](https://core.telegram.org/bots/api#sendinvoice), other than the other methods, does not accept `number | string` for `chatID`. The same is true for [editMessageLiveLocation](https://core.telegram.org/bots/api#editmessagelivelocation).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

typechecks

**Test Configuration**:
* Node.js Version: v12 and v16
* Operating System: Arch Linux

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
