### PR TITLE
Fix creating https hook instead of http

### DIFF
--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -141,7 +141,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
         ? (req, res) => webhookCb(req, res, () => cb(req, res))
         : webhookCb
     this.webhookServer =
-      tlsOptions !== undefined
+      tlsOptions != undefined
         ? https.createServer(tlsOptions, callback)
         : http.createServer(callback)
     this.webhookServer.listen(port, host, () => {


### PR DESCRIPTION
# Description

Faced a problem when creating HTTP hook and using it `null` as `ttlOptions` (as specified in the documentation https://telegraf.js.org/#production), the HTTPS server is created.

Changed the check of `undefined` to the non-strict check

Mentioned in https://github.com/telegraf/telegraf/issues/1299

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually with Nginx as proxy

# Checklist:

- 

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
