### PR TITLE
Export typings from composer

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -5,16 +5,16 @@ import * as tt from './telegram-types'
 import { Middleware, MiddlewareFn, MiddlewareObj } from './middleware'
 import Context from './context'
 
-type MaybeArray<T> = T | T[]
+export type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
-type NonemptyReadonlyArray<T> = readonly [T, ...T[]]
-type Triggers<C> = MaybeArray<
+export type NonemptyReadonlyArray<T> = readonly [T, ...T[]]
+export type Triggers<C> = MaybeArray<
   string | RegExp | ((value: string, ctx: C) => RegExpExecArray | null)
 >
-type Predicate<T> = (t: T) => boolean
-type AsyncPredicate<T> = (t: T) => Promise<boolean>
+export type Predicate<T> = (t: T) => boolean
+export type AsyncPredicate<T> = (t: T) => Promise<boolean>
 
-type MatchedMiddleware<
+export type MatchedMiddleware<
   C extends Context,
   T extends tt.UpdateType | tt.MessageSubType = 'message' | 'channel_post'
 > = NonemptyReadonlyArray<
@@ -25,7 +25,7 @@ type MatchedMiddleware<
     Produces: a context that has some properties required, and some undefined.
     The required ones are those that are always present when the given update (or message) arrives.
     The undefined ones are those that are always absent when the given update (or message) arrives. */
-type MatchedContext<
+export type MatchedContext<
   C extends Context,
   T extends tt.UpdateType | tt.MessageSubType
 > = NarrowedContext<C, tt.MountMap[T]>
@@ -42,7 +42,7 @@ export type NarrowedContext<
   U extends tg.Update
 > = Context<U> & Omit<C, keyof Context>
 
-interface GameQueryUpdate extends tg.Update.CallbackQueryUpdate {
+export interface GameQueryUpdate extends tg.Update.CallbackQueryUpdate {
   callback_query: tg.CallbackQuery.GameShortGameCallbackQuery
 }
 

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -25,7 +25,8 @@ export type MatchedMiddleware<
     Produces: a context that has some properties required, and some undefined.
     The required ones are those that are always present when the given update (or message) arrives.
     The undefined ones are those that are always absent when the given update (or message) arrives. */
-export type MatchedContext<
+/** @deprecated */
+type MatchedContext<
   C extends Context,
   T extends tt.UpdateType | tt.MessageSubType
 > = NarrowedContext<C, tt.MountMap[T]>


### PR DESCRIPTION
# Description

I often create separated file for handling command, text, etc.
`index.ts`:
```ts
import { start } from './handling/start.ts'
bot.start(start)
```

`start.ts`:
```ts
import { StartContext } from "../typings/bot"

export const start = async (ctx: StartContext): Promise<void> => {
  ctx.reply(`Start message`)
}

```

But things getting really messy on my typings
`bot.d.ts`:
```ts
import { Context, NarrowedContext } from 'telegraf'
import { Update, Message } from 'typegram'
import * as tt from 'telegraf/src/telegram-types'

export type StartContext = Context<{
  message: Update.New & Update.NonChannel & Message.TextMessage
  update_id: number
}> &
  Omit<Context<Update>, keyof Context<Update>> & {
    startPayload: string
  }

export type MatchedContext<
  C extends Context,
  T extends tt.UpdateType | tt.MessageSubType
> = NarrowedContext<C, tt.MountMap[T]>


export type TextContext = MatchedContext<Context<Update>, 'text'>

```

It will be a lot better if typings in the `composer.ts` is exported. Thanks.