### PR TITLE
Add an extra arguments(ipAddress, maxConnections) to Telegraf::launch

### DIFF
--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -53,6 +53,15 @@ export namespace Telegraf {
       host?: string
       port?: number
 
+      /** The fixed IP address which will be used to send webhook requests instead of the IP address resolved through DNS */
+      ipAddress?: string
+
+      /**
+       * Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery, 1-100. Defaults to 40.
+       * Use lower values to limit the load on your bot's server, and higher values to increase your bot's throughput.
+       */
+      maxConnections?: number
+
       /** TLS server options. Omit to use http. */
       tlsOptions?: TlsOptions
 
@@ -194,6 +203,8 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     await this.telegram.setWebhook(`https://${domain}${hookPath}`, {
       drop_pending_updates: config.dropPendingUpdates,
       allowed_updates: config.allowedUpdates,
+      ip_address: config.webhook.ipAddress,
+      max_connections: config.webhook.maxConnections,
     })
     debug(`Bot started with webhook @ https://${domain}`)
   }


### PR DESCRIPTION
# Description

Provided  `ip_address` and `max_connections` extra options to `launch` method

https://core.telegram.org/bots/api#setwebhook

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verified that new options work and don't break backward compatibility

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
