### PR TITLE
Bot API 5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telegraf",
-  "version": "4.4.2",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "telegraf",
-      "version": "4.4.2",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -17,7 +17,7 @@
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
         "sandwich-stream": "^2.0.2",
-        "typegram": "^3.6.1"
+        "typegram": "^3.7.0"
       },
       "bin": {
         "telegraf": "bin/telegraf"
@@ -5161,9 +5161,9 @@
       }
     },
     "node_modules/typegram": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.6.1.tgz",
-      "integrity": "sha512-O2UVlC7qMFSpAf7wpmPecAJMOHk2szCFt39OxnS9rzEu+1DaHLD0ZDdOqCD3PhDOa8QPiTrn0xOxxL6rKCyQJw=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.7.0.tgz",
+      "integrity": "sha512-IafMO+GRi5H8CtWSNihuD56Bjpmj/ISbg6G8jdTkNxldrym+FOPlo/fxtaPs/LyWnS0l1Bm18MUDwOikZSKmJw=="
     },
     "node_modules/typescript": {
       "version": "4.5.2",
@@ -9511,9 +9511,9 @@
       }
     },
     "typegram": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.6.1.tgz",
-      "integrity": "sha512-O2UVlC7qMFSpAf7wpmPecAJMOHk2szCFt39OxnS9rzEu+1DaHLD0ZDdOqCD3PhDOa8QPiTrn0xOxxL6rKCyQJw=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.7.0.tgz",
+      "integrity": "sha512-IafMO+GRi5H8CtWSNihuD56Bjpmj/ISbg6G8jdTkNxldrym+FOPlo/fxtaPs/LyWnS0l1Bm18MUDwOikZSKmJw=="
     },
     "typescript": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "description": "Modern Telegram Bot Framework",
   "license": "MIT",
   "author": "Vitaly Domnikov <oss@vitaly.codes>",
@@ -51,7 +51,7 @@
     "p-timeout": "^4.1.0",
     "safe-compare": "^1.1.4",
     "sandwich-stream": "^2.0.2",
-    "typegram": "^3.6.1"
+    "typegram": "^3.7.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -85,7 +85,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
     updateType: MaybeArray<T>,
     ...fns: NonemptyReadonlyArray<Middleware<MatchedContext<C, T>>>
   ) {
-    return this.use(Composer.mount<C, T>(updateType, ...fns))
+    return this.use(Composer.on<C, T>(updateType, ...fns))
   }
 
   /**
@@ -367,7 +367,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
    * })
    * ```
    *
-   * Note that `Composer.mount('message')` is preferred over this.
+   * Note that `Composer.on('message')` is preferred over this.
    *
    * @param guardFn predicate to decide whether to run the middleware based on the `ctx.update` object
    * @param fns middleware to run if the predicate returns true
@@ -595,7 +595,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
     triggers: Triggers<C>,
     ...fns: MatchedMiddleware<C, 'text'>
   ): MiddlewareFn<C> {
-    return Composer.mount(
+    return Composer.on(
       'text',
       Composer.match<C, 'text'>(normalizeTriggers(triggers), ...fns)
     )
@@ -613,7 +613,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
       return Composer.entity('bot_command', command)
     }
     const commands = normalizeTextArguments(command, '/')
-    return Composer.mount<C, 'text'>(
+    return Composer.on<C, 'text'>(
       'text',
       Composer.lazy<MatchedContext<C, 'text'>>((ctx) => {
         const groupCommands =
@@ -639,7 +639,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
     triggers: Triggers<C>,
     ...fns: MatchedMiddleware<C, 'callback_query'>
   ): MiddlewareFn<C> {
-    return Composer.mount(
+    return Composer.on(
       'callback_query',
       Composer.match<C, 'callback_query'>(normalizeTriggers(triggers), ...fns)
     )
@@ -652,7 +652,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
     triggers: Triggers<C>,
     ...fns: MatchedMiddleware<C, 'inline_query'>
   ): MiddlewareFn<C> {
-    return Composer.mount(
+    return Composer.on(
       'inline_query',
       Composer.match<C, 'inline_query'>(normalizeTriggers(triggers), ...fns)
     )

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -192,6 +192,10 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
     return this.use(Composer.cashtag<C>(cashtag, ...fns))
   }
 
+  spoiler(text: Triggers<C>, ...fns: MatchedMiddleware<C>) {
+    return this.use(Composer.spoiler<C>(text, ...fns))
+  }
+
   /**
    * Registers a middleware for handling /start
    */
@@ -543,6 +547,13 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
       normalizeTextArguments(cashtag, '$'),
       ...fns
     )
+  }
+
+  static spoiler<C extends Context>(
+    text: Triggers<C>,
+    ...fns: MatchedMiddleware<C>
+  ): MiddlewareFn<C> {
+    return Composer.entityText<C>('spoiler', text, ...fns)
   }
 
   private static match<


### PR DESCRIPTION
Support for [Bot API 5.6](https://core.telegram.org/bots/api#december-30-2021)

# Description

* Updated typegram to 3.7.0.
* Added `Composer.spoiler` and `Composer#spoiler` methods.