### PR TITLE
Fix example of setting self-signed certificate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ const tlsOptions = {
 // The second argument is necessary only if the client uses a self-signed
 // certificate. Including it for a verified certificate may cause things to break.
 bot.telegram.setWebhook('https://server.tld:8443/secret-path', {
-  source: 'server-cert.pem'
+  certificate: { source: fs.readFileSync('server-cert.pem') }
 })
 
 // Start https webhook


### PR DESCRIPTION
# Description

<!--
Please include:
- motivation,
- summary of the changes,
- list of fixed issues: https://github.blog/2013-05-14-closing-issues-via-pull-requests/
-
-->
- motivation
Fix example of passing self-signed certificate to telegram
- summary of the changes
Fix example of passing self-signed certificate to telegram

## Type of change

- Documentation
<!--
Please delete options that are not relevant.

- Documentation (typos, code examples or any documentation update)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
-->

# How Has This Been Tested?

Spent a week trying to figuring out why example does not work.
That's working on my machine at least, original example leads to "SSL error {error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed}" error 

<!--
CI typechecks, lints and runs the test suite.
If you did any extra manual tests, please describe them here.

**Test Configuration**:
* Node.js Version:
* Operating System:
-->

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
