### PR TITLE
feat: API 6.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/strict-boolean-expressions": "off"
   },
-  "ignorePatterns": ["/lib/", "/typings/", "/docs/", "/test/"],
+  "ignorePatterns": ["/lib/", "/typings/", "/docs/", "/test/", "types.d.ts"],
   "reportUnusedDisableDirectives": true,
   "plugins": ["ava"]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Modern Telegram Bot API framework for Node.js
 
-[![Bot API Version](https://img.shields.io/badge/Bot%20API-v5.7-f36caf.svg?style=flat-square)](https://core.telegram.org/bots/api)
+[![Bot API Version](https://img.shields.io/badge/Bot%20API-v6.0-f36caf.svg?style=flat-square)](https://core.telegram.org/bots/api)
 [![install size](https://flat.badgen.net/packagephobia/install/telegraf)](https://packagephobia.com/result?p=telegraf,node-telegram-bot-api)
 [![GitHub top language](https://img.shields.io/github/languages/top/telegraf/telegraf?style=flat-square&logo=github)](https://github.com/telegraf/telegraf)
 [![English chat](https://img.shields.io/badge/English%20chat-grey?style=flat-square&logo=telegram)](https://t.me/TelegrafJSChat)
@@ -27,7 +27,7 @@ Telegraf is a library that makes it simple for you to develop your own Telegram 
 
 ### Features
 
-- Full [Telegram Bot API 5.7](https://core.telegram.org/bots/api) support
+- Full [Telegram Bot API 6.0](https://core.telegram.org/bots/api) support
 - [Excellent TypeScript typings](https://github.com/telegraf/telegraf/releases/tag/v4.0.0)
 - [Lightweight](https://packagephobia.com/result?p=telegraf,node-telegram-bot-api)
 - [AWS **λ**](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "abort-controller": "^3.0.0",
         "debug": "^4.3.3",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "module-alias": "^2.2.2",
         "node-fetch": "^2.6.7",
         "p-timeout": "^4.1.0",
@@ -3019,9 +3019,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/module-alias": {
       "version": "2.2.2",
@@ -6360,9 +6360,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "module-alias": {
       "version": "2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telegraf",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "telegraf",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -17,7 +17,7 @@
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
         "sandwich-stream": "^2.0.2",
-        "typegram": "^3.8.0"
+        "typegram": "^3.9.0"
       },
       "bin": {
         "telegraf": "bin/telegraf"
@@ -3998,9 +3998,9 @@
       }
     },
     "node_modules/typegram": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.8.0.tgz",
-      "integrity": "sha512-MdlbWu0HfmgFJf4+xj6eqGYuanV2LJxBYTzLrD0kTV+woQ5dxDD2k8UVVjYnbBGkAagAyxzQevPiFZRWLFHSBw=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.9.0.tgz",
+      "integrity": "sha512-uXA93E7pmdBcL8oxsC2MRdah4qF72g2bUeCWWS6N6IbzlMrsn4uBwVw+RMQoG0ky10KP0gpsQ8lZ7P/jqVno5g=="
     },
     "node_modules/typescript": {
       "version": "4.5.5",
@@ -7054,9 +7054,9 @@
       }
     },
     "typegram": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.8.0.tgz",
-      "integrity": "sha512-MdlbWu0HfmgFJf4+xj6eqGYuanV2LJxBYTzLrD0kTV+woQ5dxDD2k8UVVjYnbBGkAagAyxzQevPiFZRWLFHSBw=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.9.0.tgz",
+      "integrity": "sha512-uXA93E7pmdBcL8oxsC2MRdah4qF72g2bUeCWWS6N6IbzlMrsn4uBwVw+RMQoG0ky10KP0gpsQ8lZ7P/jqVno5g=="
     },
     "typescript": {
       "version": "4.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Modern Telegram Bot Framework",
   "license": "MIT",
   "author": "Vitaly Domnikov <oss@vitaly.codes>",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "src/**/*.ts",
     "lib/**/*.js",
     "typings/**/*.d.ts",
-    "typings/**/*.d.ts.map"
+    "typings/**/*.d.ts.map",
+    "types.d.ts"
   ],
   "bin": {
     "telegraf": "bin/telegraf"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "p-timeout": "^4.1.0",
     "safe-compare": "^1.1.4",
     "sandwich-stream": "^2.0.2",
-    "typegram": "^3.8.0"
+    "typegram": "^3.9.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "debug": "^4.3.3",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "module-alias": "^2.2.2",
     "node-fetch": "^2.6.7",
     "p-timeout": "^4.1.0",

--- a/src/button.ts
+++ b/src/button.ts
@@ -93,3 +93,15 @@ export function login(
     hide,
   }
 }
+
+export function webApp(
+  text: string,
+  url: string,
+  hide = false
+): Hideable<InlineKeyboardButton.WebAppButton> {
+  return {
+    text,
+    web_app: { url },
+    hide,
+  }
+}

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -8,6 +8,12 @@ import Context from './context'
 export type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
 export type NonemptyReadonlyArray<T> = readonly [T, ...T[]]
+export type DefinitelyDefined<T> = T extends infer S | undefined ? S : T
+export type Expand<T> = T extends object
+  ? T extends infer O
+    ? { [K in keyof O]: O[K] }
+    : never
+  : T
 export type Triggers<C> = MaybeArray<
   string | RegExp | ((value: string, ctx: C) => RegExpExecArray | null)
 >
@@ -44,7 +50,11 @@ export type NarrowedContext<
 > = Context<U> & Omit<C, keyof Context>
 
 export interface GameQueryUpdate extends tg.Update.CallbackQueryUpdate {
-  callback_query: tg.CallbackQuery.GameShortGameCallbackQuery
+  callback_query: Expand<
+    Omit<tg.CallbackQuery, 'data'> & {
+      game_short_name: DefinitelyDefined<tg.CallbackQuery['game_short_name']>
+    }
+  >
 }
 
 function always<T>(x: T) {

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -8,7 +8,6 @@ import Context from './context'
 export type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
 export type NonemptyReadonlyArray<T> = readonly [T, ...T[]]
-export type DefinitelyDefined<T> = T extends infer S | undefined ? S : T
 export type Expand<T> = T extends object
   ? T extends infer O
     ? { [K in keyof O]: O[K] }
@@ -52,7 +51,7 @@ export type NarrowedContext<
 export interface GameQueryUpdate extends tg.Update.CallbackQueryUpdate {
   callback_query: Expand<
     Omit<tg.CallbackQuery, 'data'> & {
-      game_short_name: DefinitelyDefined<tg.CallbackQuery['game_short_name']>
+      game_short_name: NonNullable<tg.CallbackQuery['game_short_name']>
     }
   >
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -903,6 +903,42 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     this.assert(this.chat, 'unbanChatSenderChat')
     return this.telegram.unbanChatSenderChat(this.chat.id, senderChatId)
   }
+
+  /**
+   * Use this method to change the bot's menu button in the current private chat. Returns true on success.
+   * @see https://core.telegram.org/bots/api#setchatmenubutton
+   */
+  setChatMenuButton(this: Context, menuButton?: tg.MenuButton) {
+    this.assert(this.chat, 'setChatMenuButton')
+    return this.telegram.setChatMenuButton({ chatId: this.chat.id, menuButton })
+  }
+
+  /**
+   * Use this method to get the current value of the bot's menu button in the current private chat. Returns MenuButton on success.
+   * @see https://core.telegram.org/bots/api#getchatmenubutton
+   */
+  getChatMenuButton() {
+    this.assert(this.chat, 'getChatMenuButton')
+    return this.telegram.getChatMenuButton()
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#setmydefaultadministratorrights
+   */
+  setMyDefaultAdministratorRights(
+    extra?: Parameters<Telegram['setMyDefaultAdministratorRights']>[0]
+  ) {
+    return this.telegram.setMyDefaultAdministratorRights(extra)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#getmydefaultadministratorrights
+   */
+  getMyDefaultAdministratorRights(
+    extra?: Parameters<Telegram['getMyDefaultAdministratorRights']>[0]
+  ) {
+    return this.telegram.getMyDefaultAdministratorRights(extra)
+  }
 }
 
 export default Context

--- a/src/context.ts
+++ b/src/context.ts
@@ -905,13 +905,6 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#answerwebappquery
-   */
-  answerWebAppQuery(webAppQueryId: string, result: tg.InlineQueryResult) {
-    return this.telegram.answerWebAppQuery(webAppQueryId, result)
-  }
-
-  /**
    * Use this method to change the bot's menu button in the current private chat. Returns true on success.
    * @see https://core.telegram.org/bots/api#setchatmenubutton
    */

--- a/src/context.ts
+++ b/src/context.ts
@@ -136,6 +136,31 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     return this.message?.passport_data
   }
 
+  get webAppData() {
+    if (
+      !(
+        'message' in this.update &&
+        this.update.message &&
+        'web_app_data' in this.update.message
+      )
+    )
+      return undefined
+
+    const { data, button_text } = this.update.message.web_app_data
+
+    return {
+      data: {
+        json<T>() {
+          return JSON.parse(data) as T
+        },
+        text() {
+          return data
+        },
+      },
+      button_text,
+    }
+  }
+
   /**
    * @deprecated use {@link Telegram.webhookReply}
    */

--- a/src/context.ts
+++ b/src/context.ts
@@ -919,7 +919,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
    */
   getChatMenuButton() {
     this.assert(this.chat, 'getChatMenuButton')
-    return this.telegram.getChatMenuButton()
+    return this.telegram.getChatMenuButton({ chatId: this.chat.id })
   }
 
   /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -905,6 +905,13 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   }
 
   /**
+   * @see https://core.telegram.org/bots/api#answerwebappquery
+   */
+  answerWebAppQuery(webAppQueryId: string, result: tg.InlineQueryResult) {
+    return this.telegram.answerWebAppQuery(webAppQueryId, result)
+  }
+
+  /**
    * Use this method to change the bot's menu button in the current private chat. Returns true on success.
    * @see https://core.telegram.org/bots/api#setchatmenubutton
    */

--- a/src/core/types/typegram.ts
+++ b/src/core/types/typegram.ts
@@ -2,7 +2,8 @@ import { Typegram } from 'typegram'
 
 // internal type provisions
 export * from 'typegram/api'
-export * from 'typegram/callback'
+export * from 'typegram/markup'
+export * from 'typegram/menu-button'
 export * from 'typegram/inline'
 export * from 'typegram/manage'
 export * from 'typegram/message'

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -743,9 +743,9 @@ export class Telegram extends ApiClient {
     })
   }
 
-  answerWebAppQuery(web_app_query_id: string, result: tg.InlineQueryResult) {
+  answerWebAppQuery(webAppQueryId: string, result: tg.InlineQueryResult) {
     return this.callApi('answerWebAppQuery', {
-      web_app_query_id,
+      web_app_query_id: webAppQueryId,
       result,
     })
   }

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1119,7 +1119,7 @@ export class Telegram extends ApiClient {
   /**
    * Use this method to change the bot's menu button in a private chat, or the default menu button. Returns true on success.
    * @param chatId Unique identifier for the target private chat. If not specified, default bot's menu button will be changed.
-   * @param menuButton An object for the new bot's menu button.
+   * @param menuButton An object for the bot's new menu button.
    */
   setChatMenuButton({
     chatId,

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -743,6 +743,13 @@ export class Telegram extends ApiClient {
     })
   }
 
+  answerWebAppQuery(web_app_query_id: string, result: tg.InlineQueryResult) {
+    return this.callApi('answerWebAppQuery', {
+      web_app_query_id,
+      result,
+    })
+  }
+
   /**
    * Edit text and game messages sent by the bot or via the bot (for inline bots).
    * On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
@@ -1106,6 +1113,63 @@ export class Telegram extends ApiClient {
     return this.callApi('unbanChatSenderChat', {
       chat_id: chatId,
       sender_chat_id: senderChatId,
+    })
+  }
+
+  /**
+   * Use this method to change the bot's menu button in a private chat, or the default menu button. Returns true on success.
+   * @param chatId Unique identifier for the target private chat. If not specified, default bot's menu button will be changed.
+   * @param menuButton An object for the new bot's menu button.
+   */
+  setChatMenuButton({
+    chatId,
+    menuButton,
+  }: {
+    chatId?: number | undefined
+    menuButton?: tg.MenuButton | undefined
+  } = {}) {
+    return this.callApi('setChatMenuButton', {
+      chat_id: chatId,
+      menu_button: menuButton,
+    })
+  }
+
+  /**
+   * Use this method to get the current value of the bot's menu button in a private chat, or the default menu button. Returns MenuButton on success.
+   * @param chatId Unique identifier for the target private chat. If not specified, default bot's menu button will be returned.
+   */
+  getChatMenuButton({ chatId }: { chatId?: number } = {}) {
+    return this.callApi('getChatMenuButton', {
+      chat_id: chatId,
+    })
+  }
+
+  /**
+   * Use this method to change the default administrator rights requested by the bot when it's added as an administrator to groups or channels.
+   * These rights will be suggested to users, but they are are free to modify the list before adding the bot.
+   */
+  setMyDefaultAdministratorRights({
+    rights,
+    forChannels,
+  }: {
+    rights?: tg.ChatAdministratorRights
+    forChannels?: boolean
+  } = {}) {
+    return this.callApi('setMyDefaultAdministratorRights', {
+      rights,
+      for_channels: forChannels,
+    })
+  }
+
+  /**
+   * Use this method to get the current default administrator rights of the bot. Returns ChatAdministratorRights on success.
+   * @param forChannels Pass true to get default administrator rights of the bot in channels. Otherwise, default administrator rights of the bot for groups and supergroups will be returned.
+   */
+  getMyDefaultAdministratorRights({
+    forChannels,
+  }: { forChannels?: boolean } = {}) {
+    return this.callApi('getMyDefaultAdministratorRights', {
+      for_channels: forChannels,
     })
   }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,2 @@
+/** Experimental exports, shape of type exports may change in the future */
+export * from './typings/core/types/typegram'


### PR DESCRIPTION
* Upgrade to typegram@3.9.0; Bot API 6.0 support
* Update minimist to latest, resolves a [vulnerability](https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795)
* Added `Markup.button.webApp` helper
* Experimental!: ⚠️ typegram & telegraf types exported as `telegraf/types` to be imported directly without relying on a separate dependency on `typegram`. The export interface is not stable. It may change at a later date

Try it out before it lands using `npm install telegraf@canary`