### PR TITLE
Add support for test environment

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -46,7 +46,8 @@ namespace ApiClient {
      * @see https://github.com/tdlight-team/tdlight-telegram-bot-api#user-mode
      */
     apiMode: 'bot' | 'user'
-    webhookReply: boolean
+    webhookReply: boolean,
+    testEnv: boolean
   }
 
   export interface CallApiOptions {
@@ -73,6 +74,7 @@ const DEFAULT_OPTIONS: ApiClient.Options = {
     keepAliveMsecs: 10000,
   }),
   attachmentAgent: undefined,
+  testEnv: false
 }
 
 function includesMedia(payload: Record<string, unknown>) {
@@ -353,7 +355,7 @@ class ApiClient {
         )
       : await buildJSONConfig(payload)
     const apiUrl = new URL(
-      `./${options.apiMode}${token}/${method}`,
+      `./${options.apiMode}${token}${options.testEnv ? '/test' : ''}/${method}`,
       options.apiRoot
     )
     config.agent = options.agent


### PR DESCRIPTION
# Description

Added support for [Using bots in the test environment](https://core.telegram.org/bots/webapps#using-bots-in-the-test-environment)

## Type of change

Pass testEnv option to enable test environment

```javascript
const bot = new Telegraf('<token>', {
  testEnv: true
})
```

# How Has This Been Tested?

**Test Configuration**:
* Node.js Version: 16.14.0
* Operating System: Ubuntu 20.04

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
