### PR TITLE
Add ctx.send* methods and optional useNewReplies from telegraf/future

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,8 @@
     "/typings/",
     "/docs/",
     "/test/",
-    "/types.*"
+    "/types.*",
+    "/future.*"
   ],
   "reportUnusedDisableDirectives": true,
   "plugins": ["ava"]

--- a/future.d.ts
+++ b/future.d.ts
@@ -1,0 +1,1 @@
+export * from './typings/future'

--- a/future.js
+++ b/future.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/future')

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lib/**/*.js",
     "typings/**/*.d.ts",
     "typings/**/*.d.ts.map",
-    "types.*"
+    "types.*",
+    "future.*"
   ],
   "bin": {
     "telegraf": "bin/telegraf.mjs"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
       "require": "./lib/index.js",
       "import": "./lib/index.js"
     },
+    "./future": {
+      "types": "./future.d.ts",
+      "require": "./future.js",
+      "import": "./future.js"
+    },
     "./types": {
       "types": "./types.d.ts",
       "require": "./types.js",

--- a/release-notes/4.9.0.md
+++ b/release-notes/4.9.0.md
@@ -6,6 +6,8 @@
 * Added method `Telegraf::createWebhook` which calls `setWebhook` first, and returns Promise of Express-style middleware. [[Example]](https://github.com/feathers-studio/telegraf-docs/blob/master/examples/webhook/express.ts)
 * Updated Telegraf binary; it is now written in TS, and supports ESM modules and new command-line options `--method` and `--data` to call API methods from the command-line.
 * Added experimental export of Telegraf's convenience types, such as the `Extra*` parameter types, now found as: `import type { Convenience } from "telegraf/types"`
+* Added `Context::sendMessage` and `Context:sendWith*` methods mirroring `Context::reply` and `Context::replyWith*` methods respectively.
+* Added new middleware: `import { useNewReplies } from telegraf/future` that changes the behaviour of `Context::reply*` methods to actually reply to the context message.
 * (docs) New documentation effort started at [feathers-studio/telegraf-docs](https://github.com/feathers-studio/telegraf-docs).
 * (docs) All doc examples were moved to new repo and updated to full TS and ESM.
 * (internal) Removed `Telegraf::handleUpdates`.

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,7 @@ import * as tg from './core/types/typegram'
 import * as tt from './telegram-types'
 import { Deunionize, PropOr, UnionKeys } from './deunionize'
 import ApiClient from './core/network/client'
+import { deprecate } from './util'
 import Telegram from './telegram'
 
 type Tail<T> = T extends [unknown, ...infer U] ? U : never
@@ -173,7 +174,10 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     this.telegram.webhookReply = enable
   }
 
-  private assert<T extends string | object>(
+  /**
+   * @internal
+   */
+  assert<T extends string | object>(
     value: T | undefined,
     method: string
   ): asserts value is T {
@@ -351,9 +355,22 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendmessage
    */
-  reply(this: Context, ...args: Shorthand<'sendMessage'>) {
-    this.assert(this.chat, 'reply')
+  sendMessage(this: Context, ...args: Shorthand<'sendMessage'>) {
+    this.assert(this.chat, 'sendMessage')
     return this.telegram.sendMessage(this.chat.id, ...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendmessage
+   */
+  reply(this: Context, ...args: Shorthand<'sendMessage'>) {
+    deprecate(
+      'ctx.reply',
+      'reply',
+      'sendMessage',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendMessage(...args)
   }
 
   /**
@@ -573,115 +590,297 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithphoto
+   * @see https://core.telegram.org/bots/api#sendphoto
    */
-  replyWithPhoto(this: Context, ...args: Shorthand<'sendPhoto'>) {
-    this.assert(this.chat, 'replyWithPhoto')
+  sendPhoto(this: Context, ...args: Shorthand<'sendPhoto'>) {
+    this.assert(this.chat, 'sendPhoto')
     return this.telegram.sendPhoto(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithmediagroup
+   * @see https://core.telegram.org/bots/api#sendphoto
    */
-  replyWithMediaGroup(this: Context, ...args: Shorthand<'sendMediaGroup'>) {
-    this.assert(this.chat, 'replyWithMediaGroup')
+  replyWithPhoto(this: Context, ...args: Shorthand<'sendPhoto'>) {
+    deprecate(
+      'ctx.replyWithPhoto',
+      'reply',
+      'sendPhoto',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendPhoto(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendmediagroup
+   */
+  sendMediaGroup(this: Context, ...args: Shorthand<'sendMediaGroup'>) {
+    this.assert(this.chat, 'sendMediaGroup')
     return this.telegram.sendMediaGroup(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithaudio
+   * @see https://core.telegram.org/bots/api#sendmediagroup
    */
-  replyWithAudio(this: Context, ...args: Shorthand<'sendAudio'>) {
-    this.assert(this.chat, 'replyWithAudio')
+  replyWithMediaGroup(this: Context, ...args: Shorthand<'sendMediaGroup'>) {
+    deprecate(
+      'ctx.replyWithMediaGroup',
+      'reply',
+      'sendMediaGroup',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendMediaGroup(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendaudio
+   */
+  sendAudio(this: Context, ...args: Shorthand<'sendAudio'>) {
+    this.assert(this.chat, 'sendAudio')
     return this.telegram.sendAudio(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithdice
+   * @see https://core.telegram.org/bots/api#sendaudio
    */
-  replyWithDice(this: Context, ...args: Shorthand<'sendDice'>) {
-    this.assert(this.chat, 'replyWithDice')
+  replyWithAudio(this: Context, ...args: Shorthand<'sendAudio'>) {
+    deprecate(
+      'ctx.replyWithAudio',
+      'reply',
+      'sendAudio',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendAudio(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#senddice
+   */
+  sendDice(this: Context, ...args: Shorthand<'sendDice'>) {
+    this.assert(this.chat, 'sendDice')
     return this.telegram.sendDice(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithdocument
+   * @see https://core.telegram.org/bots/api#senddice
    */
-  replyWithDocument(this: Context, ...args: Shorthand<'sendDocument'>) {
-    this.assert(this.chat, 'replyWithDocument')
+  replyWithDice(this: Context, ...args: Shorthand<'sendDice'>) {
+    deprecate(
+      'ctx.replyWithDice',
+      'reply',
+      'sendDice',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendDice(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#senddocument
+   */
+  sendDocument(this: Context, ...args: Shorthand<'sendDocument'>) {
+    this.assert(this.chat, 'sendDocument')
     return this.telegram.sendDocument(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithsticker
+   * @see https://core.telegram.org/bots/api#senddocument
    */
-  replyWithSticker(this: Context, ...args: Shorthand<'sendSticker'>) {
-    this.assert(this.chat, 'replyWithSticker')
+  replyWithDocument(this: Context, ...args: Shorthand<'sendDocument'>) {
+    deprecate(
+      'ctx.replyWithDocument',
+      'reply',
+      'sendDocument',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendDocument(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendsticker
+   */
+  sendSticker(this: Context, ...args: Shorthand<'sendSticker'>) {
+    this.assert(this.chat, 'sendSticker')
     return this.telegram.sendSticker(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithvideo
+   * @see https://core.telegram.org/bots/api#sendsticker
    */
-  replyWithVideo(this: Context, ...args: Shorthand<'sendVideo'>) {
-    this.assert(this.chat, 'replyWithVideo')
+  replyWithSticker(this: Context, ...args: Shorthand<'sendSticker'>) {
+    deprecate(
+      'ctx.replyWithSticker',
+      'reply',
+      'sendSticker',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendSticker(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendvideo
+   */
+  sendVideo(this: Context, ...args: Shorthand<'sendVideo'>) {
+    this.assert(this.chat, 'sendVideo')
     return this.telegram.sendVideo(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithanimation
+   * @see https://core.telegram.org/bots/api#sendvideo
    */
-  replyWithAnimation(this: Context, ...args: Shorthand<'sendAnimation'>) {
-    this.assert(this.chat, 'replyWithAnimation')
+  replyWithVideo(this: Context, ...args: Shorthand<'sendAudio'>) {
+    deprecate(
+      'ctx.replyWithVideo',
+      'reply',
+      'sendVideo',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendVideo(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendanimation
+   */
+  sendAnimation(this: Context, ...args: Shorthand<'sendAnimation'>) {
+    this.assert(this.chat, 'sendAnimation')
     return this.telegram.sendAnimation(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithvideonote
+   * @see https://core.telegram.org/bots/api#sendanimation
    */
-  replyWithVideoNote(this: Context, ...args: Shorthand<'sendVideoNote'>) {
-    this.assert(this.chat, 'replyWithVideoNote')
+  replyWithAnimation(this: Context, ...args: Shorthand<'sendAnimation'>) {
+    deprecate(
+      'ctx.replyWithAnimation',
+      'reply',
+      'sendAnimation',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendAnimation(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendvideonote
+   */
+  sendVideoNote(this: Context, ...args: Shorthand<'sendVideoNote'>) {
+    this.assert(this.chat, 'sendVideoNote')
     return this.telegram.sendVideoNote(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithinvoice
+   * @see https://core.telegram.org/bots/api#sendvideonote
    */
-  replyWithInvoice(this: Context, ...args: Shorthand<'sendInvoice'>) {
-    this.assert(this.chat, 'replyWithInvoice')
+  replyWithVideoNote(this: Context, ...args: Shorthand<'sendVideoNote'>) {
+    deprecate(
+      'ctx.replyWithVideoNote',
+      'reply',
+      'sendVideoNote',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendVideoNote(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendinvoice
+   */
+  sendInvoice(this: Context, ...args: Shorthand<'sendInvoice'>) {
+    this.assert(this.chat, 'sendInvoice')
     return this.telegram.sendInvoice(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithgame
+   * @see https://core.telegram.org/bots/api#sendinvoice
    */
-  replyWithGame(this: Context, ...args: Shorthand<'sendGame'>) {
-    this.assert(this.chat, 'replyWithGame')
+  replyWithInvoice(this: Context, ...args: Shorthand<'sendInvoice'>) {
+    deprecate(
+      'ctx.replyWithInvoice',
+      'reply',
+      'sendInvoice',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendInvoice(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendgame
+   */
+  sendGame(this: Context, ...args: Shorthand<'sendGame'>) {
+    this.assert(this.chat, 'sendGame')
     return this.telegram.sendGame(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithvoice
+   * @see https://core.telegram.org/bots/api#sendgame
    */
-  replyWithVoice(this: Context, ...args: Shorthand<'sendVoice'>) {
-    this.assert(this.chat, 'replyWithVoice')
+  replyWithGame(this: Context, ...args: Shorthand<'sendGame'>) {
+    deprecate(
+      'ctx.replyWithGame',
+      'reply',
+      'sendGame',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendGame(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendvoice
+   */
+  sendVoice(this: Context, ...args: Shorthand<'sendVoice'>) {
+    this.assert(this.chat, 'sendVoice')
     return this.telegram.sendVoice(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithpoll
+   * @see https://core.telegram.org/bots/api#sendvoice
    */
-  replyWithPoll(this: Context, ...args: Shorthand<'sendPoll'>) {
-    this.assert(this.chat, 'replyWithPoll')
+  replyWithVoice(this: Context, ...args: Shorthand<'sendVoice'>) {
+    deprecate(
+      'ctx.replyWithVoice',
+      'reply',
+      'sendVoice',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendVoice(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendpoll
+   */
+  sendPoll(this: Context, ...args: Shorthand<'sendPoll'>) {
+    this.assert(this.chat, 'sendPoll')
     return this.telegram.sendPoll(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithquiz
+   * @see https://core.telegram.org/bots/api#sendpoll
+   */
+  replyWithPoll(this: Context, ...args: Shorthand<'sendPoll'>) {
+    deprecate(
+      'ctx.replyWithPoll',
+      'reply',
+      'sendPoll',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendPoll(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendquiz
+   */
+  sendQuiz(this: Context, ...args: Shorthand<'sendQuiz'>) {
+    this.assert(this.chat, 'sendQuiz')
+    return this.telegram.sendQuiz(this.chat.id, ...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendquiz
    */
   replyWithQuiz(this: Context, ...args: Shorthand<'sendQuiz'>) {
-    this.assert(this.chat, 'replyWithQuiz')
-    return this.telegram.sendQuiz(this.chat.id, ...args)
+    deprecate(
+      'ctx.replyWithQuiz',
+      'reply',
+      'sendQuiz',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendQuiz(...args)
   }
 
   /**
@@ -693,35 +892,82 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithchataction
+   * @see https://core.telegram.org/bots/api#sendchataction
    */
-  replyWithChatAction(this: Context, ...args: Shorthand<'sendChatAction'>) {
-    this.assert(this.chat, 'replyWithChatAction')
+  sendChatAction(this: Context, ...args: Shorthand<'sendChatAction'>) {
+    this.assert(this.chat, 'sendChatAction')
     return this.telegram.sendChatAction(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithlocation
+   * @see https://core.telegram.org/bots/api#sendchataction
    */
-  replyWithLocation(this: Context, ...args: Shorthand<'sendLocation'>) {
-    this.assert(this.chat, 'replyWithLocation')
+  replyWithChatAction(this: Context, ...args: Shorthand<'sendChatAction'>) {
+    deprecate('ctx.replyWithChatAction', 'reply', 'sendChatAction')
+    return this.sendChatAction(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendlocation
+   */
+  sendLocation(this: Context, ...args: Shorthand<'sendLocation'>) {
+    this.assert(this.chat, 'sendLocation')
     return this.telegram.sendLocation(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithvenue
+   * @see https://core.telegram.org/bots/api#sendlocation
    */
-  replyWithVenue(this: Context, ...args: Shorthand<'sendVenue'>) {
-    this.assert(this.chat, 'replyWithVenue')
+  replyWithLocation(this: Context, ...args: Shorthand<'sendLocation'>) {
+    deprecate(
+      'ctx.replyWithLocation',
+      'reply',
+      'sendLocation',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendLocation(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendvenue
+   */
+  sendVenue(this: Context, ...args: Shorthand<'sendVenue'>) {
+    this.assert(this.chat, 'sendVenue')
     return this.telegram.sendVenue(this.chat.id, ...args)
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#replywithcontact
+   * @see https://core.telegram.org/bots/api#sendvenue
+   */
+  replyWithVenue(this: Context, ...args: Shorthand<'sendVenue'>) {
+    deprecate(
+      'ctx.replyWithVenue',
+      'reply',
+      'sendVenue',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendVenue(...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendcontact
+   */
+  sendContact(this: Context, ...args: Shorthand<'sendContact'>) {
+    this.assert(this.chat, 'sendContact')
+    return this.telegram.sendContact(this.chat.id, ...args)
+  }
+
+  /**
+   * @see https://core.telegram.org/bots/api#sendcontact
    */
   replyWithContact(this: Context, ...args: Shorthand<'sendContact'>) {
-    this.assert(this.chat, 'replyWithContact')
-    return this.telegram.sendContact(this.chat.id, ...args)
+    deprecate(
+      'ctx.replyWithContact',
+      'reply',
+      'sendContact',
+      'https://telegraf.js.org/experimental#new-reply'
+    )
+    return this.sendContact(...args)
   }
 
   /**

--- a/src/future.ts
+++ b/src/future.ts
@@ -1,0 +1,207 @@
+import Context from './context'
+import { Middleware } from './middleware'
+
+type ReplyContext = { [key in keyof Context & `reply${string}`]: Context[key] }
+
+function makeReply<
+  C extends Context,
+  E extends { reply_to_message_id?: number }
+>(ctx: C, extra?: E) {
+  const reply_to_message_id = ctx.message?.message_id
+  return { reply_to_message_id, ...extra }
+}
+
+const replyContext: ReplyContext = {
+  replyWithChatAction: function () {
+    throw new TypeError(
+      'ctx.replyWithChatAction is removed, use sendChatAction instead'
+    )
+  },
+  reply(this: Context, text, extra) {
+    this.assert(this.chat, 'reply')
+    return this.telegram.sendMessage(this.chat.id, text, makeReply(this, extra))
+  },
+  replyWithAnimation(this: Context, animation, extra) {
+    this.assert(this.chat, 'replyWithAnimation')
+    return this.telegram.sendAnimation(
+      this.chat.id,
+      animation,
+      makeReply(this, extra)
+    )
+  },
+  replyWithAudio(this: Context, audio, extra) {
+    this.assert(this.chat, 'replyWithAudio')
+    return this.telegram.sendAudio(this.chat.id, audio, makeReply(this, extra))
+  },
+  replyWithContact(this: Context, phoneNumber, firstName, extra) {
+    this.assert(this.chat, 'replyWithContact')
+    return this.telegram.sendContact(
+      this.chat.id,
+      phoneNumber,
+      firstName,
+      makeReply(this, extra)
+    )
+  },
+  replyWithDice(this: Context, extra) {
+    this.assert(this.chat, 'replyWithDice')
+    return this.telegram.sendDice(this.chat.id, makeReply(this, extra))
+  },
+  replyWithDocument(this: Context, document, extra) {
+    this.assert(this.chat, 'replyWithDocument')
+    return this.telegram.sendDocument(
+      this.chat.id,
+      document,
+      makeReply(this, extra)
+    )
+  },
+  replyWithGame(this: Context, gameName, extra) {
+    this.assert(this.chat, 'replyWithGame')
+    return this.telegram.sendGame(
+      this.chat.id,
+      gameName,
+      makeReply(this, extra)
+    )
+  },
+  replyWithHTML(this: Context, html, extra) {
+    this.assert(this.chat, 'replyWithHTML')
+    return this.telegram.sendMessage(this.chat.id, html, {
+      parse_mode: 'HTML',
+      reply_to_message_id: this.message?.message_id,
+      ...extra,
+    })
+  },
+  replyWithInvoice(this: Context, invoice, extra) {
+    this.assert(this.chat, 'replyWithInvoice')
+    return this.telegram.sendInvoice(
+      this.chat.id,
+      invoice,
+      makeReply(this, extra)
+    )
+  },
+  replyWithLocation(this: Context, latitude, longitude, extra) {
+    this.assert(this.chat, 'replyWithLocation')
+    return this.telegram.sendLocation(
+      this.chat.id,
+      latitude,
+      longitude,
+      makeReply(this, extra)
+    )
+  },
+  replyWithMarkdown(this: Context, markdown, extra) {
+    this.assert(this.chat, 'replyWithMarkdown')
+    return this.telegram.sendMessage(this.chat.id, markdown, {
+      parse_mode: 'Markdown',
+      reply_to_message_id: this.message?.message_id,
+      ...extra,
+    })
+  },
+  replyWithMarkdownV2(this: Context, markdown, extra) {
+    this.assert(this.chat, 'replyWithMarkdownV2')
+    return this.telegram.sendMessage(this.chat.id, markdown, {
+      parse_mode: 'MarkdownV2',
+      reply_to_message_id: this.message?.message_id,
+      ...extra,
+    })
+  },
+  replyWithMediaGroup(this: Context, media, extra) {
+    this.assert(this.chat, 'replyWithMediaGroup')
+    return this.telegram.sendMediaGroup(
+      this.chat.id,
+      media,
+      makeReply(this, extra)
+    )
+  },
+  replyWithPhoto(this: Context, photo, extra) {
+    this.assert(this.chat, 'replyWithPhoto')
+    return this.telegram.sendPhoto(this.chat.id, photo, makeReply(this, extra))
+  },
+  replyWithPoll(this: Context, question, options, extra) {
+    this.assert(this.chat, 'replyWithPoll')
+    return this.telegram.sendPoll(
+      this.chat.id,
+      question,
+      options,
+      makeReply(this, extra)
+    )
+  },
+  replyWithQuiz(this: Context, question, options, extra) {
+    this.assert(this.chat, 'replyWithQuiz')
+    return this.telegram.sendQuiz(
+      this.chat.id,
+      question,
+      options,
+      makeReply(this, extra)
+    )
+  },
+  replyWithSticker(this: Context, sticker, extra) {
+    this.assert(this.chat, 'replyWithSticker')
+    return this.telegram.sendSticker(
+      this.chat.id,
+      sticker,
+      makeReply(this, extra)
+    )
+  },
+  replyWithVenue(this: Context, latitude, longitude, title, address, extra) {
+    this.assert(this.chat, 'replyWithVenue')
+    return this.telegram.sendVenue(
+      this.chat.id,
+      latitude,
+      longitude,
+      title,
+      address,
+      makeReply(this, extra)
+    )
+  },
+  replyWithVideo(this: Context, video, extra) {
+    this.assert(this.chat, 'replyWithVideo')
+    return this.telegram.sendVideo(this.chat.id, video, makeReply(this, extra))
+  },
+  replyWithVideoNote(this: Context, videoNote, extra) {
+    this.assert(this.chat, 'replyWithVideoNote')
+    return this.telegram.sendVideoNote(
+      this.chat.id,
+      videoNote,
+      makeReply(this, extra)
+    )
+  },
+  replyWithVoice(this: Context, voice, extra) {
+    this.assert(this.chat, 'replyWithVoice')
+    return this.telegram.sendVoice(this.chat.id, voice, makeReply(this, extra))
+  },
+}
+
+/**
+ * Sets up Context to use the new reply methods.
+ * This middleware makes `ctx.reply()` and `ctx.replyWith*()` methods will actually reply to the message they are replying to.
+ * Use `ctx.sendMessage()` to send a message in chat without replying to it.
+ *
+ * If the message to reply is deleted, `reply()` will send a normal message.
+ * If the update is not a message and we are unable to reply, `reply()` will send a normal message.
+ */
+export function useNewReplies<C extends Context>(): Middleware<C> {
+  return (ctx, next) => {
+    ctx.reply = replyContext.reply
+    ctx.replyWithPhoto = replyContext.replyWithPhoto
+    ctx.replyWithMediaGroup = replyContext.replyWithMediaGroup
+    ctx.replyWithAudio = replyContext.replyWithAudio
+    ctx.replyWithDice = replyContext.replyWithDice
+    ctx.replyWithDocument = replyContext.replyWithDocument
+    ctx.replyWithSticker = replyContext.replyWithSticker
+    ctx.replyWithVideo = replyContext.replyWithVideo
+    ctx.replyWithAnimation = replyContext.replyWithAnimation
+    ctx.replyWithVideoNote = replyContext.replyWithVideoNote
+    ctx.replyWithInvoice = replyContext.replyWithInvoice
+    ctx.replyWithGame = replyContext.replyWithGame
+    ctx.replyWithVoice = replyContext.replyWithVoice
+    ctx.replyWithPoll = replyContext.replyWithPoll
+    ctx.replyWithQuiz = replyContext.replyWithQuiz
+    ctx.replyWithChatAction = replyContext.replyWithChatAction
+    ctx.replyWithLocation = replyContext.replyWithLocation
+    ctx.replyWithVenue = replyContext.replyWithVenue
+    ctx.replyWithContact = replyContext.replyWithContact
+    ctx.replyWithMarkdown = replyContext.replyWithMarkdown
+    ctx.replyWithMarkdownV2 = replyContext.replyWithMarkdownV2
+    ctx.replyWithHTML = replyContext.replyWithHTML
+    return next()
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,26 @@
+export const env = process.env
+
+export function deprecate(
+  method: string,
+  ignorable: string | undefined,
+  use: string | undefined,
+  see?: string
+) {
+  // don't use deprecate() yet
+  // wait for a couple minor releases of telegraf so the news reaches more people
+  return
+
+  const ignorer = `IGNORE_DEPRECATED_${ignorable}`
+  if (env[ignorer]) return
+
+  const stack: { stack: string } = { stack: '' }
+  Error.captureStackTrace(stack)
+  const line = (stack.stack.split('\n')[3] || '').trim()
+
+  const useOther = use ? `; use ${use} instead` : ''
+  const pad = ' '.repeat('[WARN]'.length)
+
+  console.warn(`[WARN] ${method} is deprecated${useOther}`)
+  if (line) console.warn(pad, line)
+  if (see) console.warn(pad, `SEE ${see}`)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "incremental": true,
     "tsBuildInfoFile": "typings/tsconfig.tsbuildinfo",
     "noErrorTruncation": true,
+    "stripInternal": true,
     "forceConsistentCasingInFileNames": true
   },
   "typedocOptions": {
@@ -21,7 +22,7 @@
     "media": "docs/assets/",
     "name": "telegraf.js",
     "out": "docs/build/",
-    "readme": "README.md",
+    "readme": "README.md"
   },
-  "include": ["src/"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
It has been a long-confusing feature of Telegraf that `ctx.reply` doesn't actually reply, but sends a message in the same chat. We now plan to fix it. This PR introduces `ctx.sendMessage`, `ctx.sendPhoto`, etc., that reflect the upstream API, but implicitly send a message in the same chat, more consistently with the other Context methods. This is the current behaviour of the `ctx.reply` methods.

This PR also introduces the new reply mode, which is optionally enabled using the `useNewReplies` middleware. Demonstration:

```TS
import { Telegraf } from "telegraf";
import { useNewReplies } from "telegraf/future";

const bot = new Telegraf(token);

// current behaviour:

bot.on("message", ctx => {
  // sends message in the same group, but doesn't reply
  ctx.reply("Hello");

  // sends message in the same group, but doesn't reply
  ctx.sendMessage("Hello");
});

bot.use(useNewReplies());

// new behaviour:

bot.on("message", ctx => {
  // actually replies to the message that was received
  ctx.reply("Hello");

  // sends message in the same group, but doesn't reply
  ctx.sendMessage("Hello");
});
```

This causes `ctx.reply`, `ctx.replyWithPhoto`, and the like to actually reply to the message in current context. If a message is not available, it will simply send a regular message.

A future minor release of telegraf will deprecate the current `ctx.reply*` methods in favour of the new ones, causing their usage to log warnings, prompting users to enable `useNewReplies`. v5 will completely replace the behaviour of `ctx.reply` with the new reply methods, ~~and an optional middleware, `useOldReplies`, to replace them with the old methods may be added.~~