### PR TITLE
Add `types` reference also to the `exports` part to fix #1629

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "lib/index.js",
   "exports": {
-    ".": { "require": "./lib/index.js", "types": "./typings/index.d.ts" },
+    ".": { "types": "./typings/index.d.ts", "require": "./lib/index.js" },
     "./types": "./types.js"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "lib/index.js",
   "exports": {
-    ".": "./lib/index.js",
+    ".": { "require": "./lib/index.js", "types": "./typings/index.d.ts" },
     "./types": "./types.js"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,8 +14,14 @@
   },
   "main": "lib/index.js",
   "exports": {
-    ".": { "types": "./typings/index.d.ts", "require": "./lib/index.js" },
-    "./types": "./types.js"
+    ".": {
+      "types": "./typings/index.d.ts",
+      "require": "./lib/index.js"
+    },
+    "./types": {
+      "types": "./types.d.ts",
+      "require": "./types.js"
+    }
   },
   "files": [
     "bin/*",


### PR DESCRIPTION
# Description / Type of change

Bugfix for #1629

See https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing for the TypeScript docs of the used `exports` change.

Note that I didn't change the `"./types"` exports entry because this seems to be only a workaround for some ESLint error, see 8ddeba23dba69e56f4da6aabdd14417ce7afeb1a.

# How Has This Been Tested?

When running `npx tsc -p .` in the repro sample (see https://github.com/telegraf/telegraf/issues/1629#issuecomment-1141257894) before the fix:

```plain
$npx tsc -p .
test.ts:1:27 - error TS7016: Could not find a declaration file for module 'telegraf'. 'C:/_work/3rdP/telegraf/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/telegraf` if it exists or add a new declaration (.d.ts) file containing `declare module 'telegraf';`

1 import * as telegraf from "telegraf"
                            ~~~~~~~~~~


Found 1 error in test.ts:1
```
... and after the fix it compiles fine.

# Checklist:

- [x] I have performed a self-review of my own code
- n/a I have made corresponding changes to the documentation
- n/a My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  -  Nope only a manual test, see above
