### PR TITLE
doc: adds new Russian chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For additional bot examples see [`examples`](https://github.com/telegraf/telegra
   * [English](https://t.me/TelegrafJSChat)
   * [Uzbek](https://t.me/botjs_uz)
   * [Ethiopian](https://t.me/telegraf_et)
+  * [Russian](https://t.me/telegrafjs_ru)
 - [GitHub Discussions](https://github.com/telegraf/telegraf/discussions)
 - [Dependent repositories](https://libraries.io/npm/telegraf/dependent_repositories)
 


### PR DESCRIPTION
# Description

Hey, I noticed that there is no chat for Russian speaking developers.

I did some research and found that it was deleted in https://github.com/telegraf/telegraf/commit/d22b4652c15815af4c84b97ecabedc5e173172fd, further research showed that it was taken private temporarily by the owners.

I’m sure they had their reasons, but since almost 4 months have past, if they are not coming back yet, I think it’s worth creating some public space for Russian speaking developers to discuss telegraf, which you can find and join easily, because the community is big. Even if it is going to be a temporary one and will be merged with the old one in the future, or they will coexist, or whatever.

Also since I found out that the owner of the old group was Vitaly, I have some doubts about whether it’s appropriate, but anyway I guess it’s up to the maintainers to decide, so here it is.

## Type of change

- Documentation (typos, code examples or any documentation update)




