### PR TITLE
Support for API v6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telegraf",
-  "version": "4.7.0",
+  "version": "4.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "telegraf",
-      "version": "4.7.0",
+      "version": "4.8.5",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -17,7 +17,7 @@
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
         "sandwich-stream": "^2.0.2",
-        "typegram": "^3.9.0"
+        "typegram": "^3.10.0"
       },
       "bin": {
         "telegraf": "bin/telegraf"
@@ -3998,9 +3998,9 @@
       }
     },
     "node_modules/typegram": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.9.0.tgz",
-      "integrity": "sha512-uXA93E7pmdBcL8oxsC2MRdah4qF72g2bUeCWWS6N6IbzlMrsn4uBwVw+RMQoG0ky10KP0gpsQ8lZ7P/jqVno5g=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.10.0.tgz",
+      "integrity": "sha512-kma7ZF7SFRqcUCgo5sHg1MbPwc9/KYjVkbvrqIZK7oXfPdLBGz1s7wF9d7o4yjHp+AOGke8cyYGhI/+4xYYC4Q=="
     },
     "node_modules/typescript": {
       "version": "4.5.5",
@@ -7054,9 +7054,9 @@
       }
     },
     "typegram": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.9.0.tgz",
-      "integrity": "sha512-uXA93E7pmdBcL8oxsC2MRdah4qF72g2bUeCWWS6N6IbzlMrsn4uBwVw+RMQoG0ky10KP0gpsQ8lZ7P/jqVno5g=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.10.0.tgz",
+      "integrity": "sha512-kma7ZF7SFRqcUCgo5sHg1MbPwc9/KYjVkbvrqIZK7oXfPdLBGz1s7wF9d7o4yjHp+AOGke8cyYGhI/+4xYYC4Q=="
     },
     "typescript": {
       "version": "4.5.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "p-timeout": "^4.1.0",
     "safe-compare": "^1.1.4",
     "sandwich-stream": "^2.0.2",
-    "typegram": "^3.9.0"
+    "typegram": "^3.10.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -141,15 +141,14 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     })
   }
 
-  private startWebhook(config: {
-    hookPath?: string
-    tlsOptions?: TlsOptions
+  private startWebhook(
+    hookPath: string,
+    tlsOptions?: TlsOptions,
+    port?: number,
+    host?: string,
+    cb?: Telegraf.WebhookCallback,
     secretToken?: string
-    port?: number
-    host?: string
-    cb?: Telegraf.WebhookCallback
-  }) {
-    const { hookPath, tlsOptions, secretToken, port, host, cb } = config
+  ) {
     const webhookCb = this.webhookCallback(hookPath)
     const callback: http.RequestListener =
       typeof cb === 'function'
@@ -202,7 +201,8 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     }
     const hookPath =
       config.webhook.hookPath ?? `/telegraf/${this.secretPathComponent()}`
-    this.startWebhook(config.webhook)
+    const { tlsOptions, port, host, cb, secretToken } = config.webhook
+    this.startWebhook(hookPath, tlsOptions, port, host, cb, secretToken)
     if (!domain) {
       debug('Bot started with webhook')
       return

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -42,6 +42,7 @@ export type ExtraCopyMessage = MakeExtra<
   'from_chat_id' | 'message_id'
 >
 export type ExtraCreateChatInviteLink = MakeExtra<'createChatInviteLink'>
+export type NewInvoiceLinkParameters = MakeExtra<'createInvoiceLink'>
 export type ExtraCreateNewStickerSet = MakeExtra<
   'createNewStickerSet',
   'name' | 'title' | 'user_id'

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -580,6 +580,12 @@ export class Telegram extends ApiClient {
     })
   }
 
+  createInvoiceLink(invoice: tt.NewInvoiceLinkParameters) {
+    return this.callApi('createInvoiceLink', {
+      ...invoice,
+    })
+  }
+
   editChatInviteLink(
     chatId: number | string,
     inviteLink: string,


### PR DESCRIPTION
# Description

# Support for v6.1


## Type of change

  * Added `createInvoiceLink` method
  * Added `secretToken` option for webhook config
  * Improve `cb` option for webhook config, for better integration with http frameworks, like: fastify, express, etc.
  * Added an auto-filter that only handles webhook requests that match the `X-Telegram-Bot-Api-Secret-Token` header when `secretToken` is set
 
   ####  Note: You can add a manual filter using `cb` option


Basic example:

 ```javascript
bot.launch({
  webhook: {
    port: +process.env.PORT,
    domain: 'yourdomain.com',
    secretToken: 'my_secret_token',
    cb: webhookHandler => {
      return (req, res) => {
        if (req.headers['x-telegram-bot-api-secret-token'] === 'my_secret_token') {
          webhookHandler(req, res)
          return res.end()
        }
      }
    }
  }
})
 ```

Example using Express:
 ```javascript
const app = require('express')()

// ...

bot.launch({
  webhook: {
    port: +process.env.PORT,
    domain: 'yourdomain.com',
    secretToken: 'my_secret_token',
    cb: webhookHandler => {
      return app.use((req, res, next) => {
        if (req.headers['x-telegram-bot-api-secret-token'] === 'my_secret_token') {
          webhookHandler(req, res, next)
          return res.end()
        }
      })
    }
  }
})
 ```


# How Has This Been Tested?

**Test Configuration**:
* Node.js Version: 16.16.0
* Operating System: Ubuntu 20.04

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
