### PR TITLE
fix(docs): link typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 <p>Modern Telegram Bot API framework for Node.js</p>
 
-<a href="https://core.telegram.org/bots/api)">
+<a href="https://core.telegram.org/bots/api">
 	<img src="https://img.shields.io/badge/Bot%20API-v6.2-f36caf.svg?style=flat-square" alt="Bot API Version" />
 </a>
-<a href="https://packagephobia.com/result?p=telegraf,node-telegram-bot-api)">
+<a href="https://packagephobia.com/result?p=telegraf,node-telegram-bot-api">
 	<img src="https://flat.badgen.net/packagephobia/install/telegraf" alt="install size" />
 </a>
-<a href="https://github.com/telegraf/telegraf)">
+<a href="https://github.com/telegraf/telegraf">
 	<img src="https://img.shields.io/github/languages/top/telegraf/telegraf?style=flat-square&logo=github" alt="GitHub top language" />
 </a>
-<a href="https://t.me/TelegrafJSChat)">
+<a href="https://t.me/TelegrafJSChat">
 	<img src="https://img.shields.io/badge/English%20chat-grey?style=flat-square&logo=telegram" alt="English chat" />
 </a>
 </div>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <a href="https://github.com/telegraf/telegraf">
 	<img src="https://img.shields.io/github/languages/top/telegraf/telegraf?style=flat-square&logo=github" alt="GitHub top language" />
 </a>
-<a href="https://t.me/TelegrafJSChat">
+<a href="https://telegram.me/TelegrafJSChat">
 	<img src="https://img.shields.io/badge/English%20chat-grey?style=flat-square&logo=telegram" alt="English chat" />
 </a>
 </div>


### PR DESCRIPTION
# Description
Corrected typos in the links and changed domain of telegram chat url from "t.me" to "telegram.me" because it's not accessbile everywhere.

## Type of change
- Documentation (typos, code examples or any documentation update)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
