### PR TITLE
Formatting helpers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
         "@typescript-eslint/no-explicit-any": "warn",
         "@typescript-eslint/no-non-null-assertion": "warn",
         "@typescript-eslint/promise-function-async": "off",
+        "@typescript-eslint/no-namespace": "off",
         "no-undef": "off"
       }
     }
@@ -32,6 +33,7 @@
     "/docs/",
     "/test/",
     "/types.*",
+    "/format.*",
     "/future.*"
   ],
   "reportUnusedDisableDirectives": true,

--- a/format.d.ts
+++ b/format.d.ts
@@ -1,0 +1,1 @@
+export * from './typings/format'

--- a/format.js
+++ b/format.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/format')

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typings/**/*.d.ts",
     "typings/**/*.d.ts.map",
     "types.*",
+    "format.*",
     "future.*"
   ],
   "bin": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "types": "./types.d.ts",
       "require": "./types.js",
       "import": "./types.js"
+    },
+    "./format": {
+      "types": "./format.d.ts",
+      "require": "./format.js",
+      "import": "./format.js"
     }
   },
   "files": [

--- a/release-notes/4.10.0.md
+++ b/release-notes/4.10.0.md
@@ -24,11 +24,18 @@
   ```TS
   import { fmt, bold, italics, mention } from "telegraf/format";
 
-  const formatted = fmt`
-    Ground control to ${mention("Major Tom", 10000000)}
-    ${bold("Lock your Soyuz hatch")} and ${italics("put your helmet on")}
-  `;
+  ctx.reply(fmt`
+  Ground control to ${mention("Major Tom", 10000000)}
+  ${bold`Lock your Soyuz hatch`} and ${italic`put your helmet on`}
+  — ${link("David Bowie", "https://en.wikipedia.org/wiki/David_Bowie")}
+  `);
+  ```
 
-  // this API will further change to accept formatted directly
-  bot.telegram.sendMessage(id, formatted.text, { entities: formatted.entities });
+  This also just works with captions!
+
+  ```TS
+  ctx.replyWithPhoto(
+    file.id,
+    { caption: fmt`${bold`File name:`} ${file.name}` },
+  );
   ```

--- a/release-notes/4.10.0.md
+++ b/release-notes/4.10.0.md
@@ -1,6 +1,7 @@
 # v4.10.0
 
 * Deprecated `ctx.replyWithMarkdown`; prefer MarkdownV2 as Telegram recommends.
+* Deprecated `ctx.replyWithChatAction`; use identical method `ctx.sendChatAction` instead.
 * `bot.launch()` webhook options now accepts `certificate` for self-signed certs.
 * Added Input helpers to create the InputFile object.
 

--- a/release-notes/4.10.0.md
+++ b/release-notes/4.10.0.md
@@ -18,3 +18,16 @@
   ```
 
   This helps clear the confusion many users have about InputFile, and provides a layer of abstraction that can be used in the future to declutter telegraf/client from having to handle all combinations of InputFile.
+* Brand new formatting helpers! No more awkward escaping.
+
+  ```TS
+  import { fmt, bold, italics, mention } from "telegraf/format";
+
+  const formatted = fmt`
+    Ground control to ${mention("Major Tom", 10000000)}
+    ${bold("Lock your Soyuz hatch")} and ${italics("put your helmet on")}
+  `;
+
+  // this API will further change to accept formatted directly
+  bot.telegram.sendMessage(id, formatted.text, { entities: formatted.entities });
+  ```

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -4,15 +4,11 @@ import * as tg from './core/types/typegram'
 import * as tt from './telegram-types'
 import { Middleware, MiddlewareFn, MiddlewareObj } from './middleware'
 import Context from './context'
+import { Expand } from './util'
 
 export type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
 export type NonemptyReadonlyArray<T> = readonly [T, ...T[]]
-export type Expand<T> = T extends object
-  ? T extends infer O
-    ? { [K in keyof O]: O[K] }
-    : never
-  : T
 export type Triggers<C> = MaybeArray<
   string | RegExp | ((value: string, ctx: C) => RegExpExecArray | null)
 >

--- a/src/context.ts
+++ b/src/context.ts
@@ -900,6 +900,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   }
 
   /**
+   * @deprecated use {@link Context.sendChatAction} instead
    * @see https://core.telegram.org/bots/api#sendchataction
    */
   replyWithChatAction(this: Context, ...args: Shorthand<'sendChatAction'>) {

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -51,12 +51,6 @@ export function _fmt(kind: Types.Text | 'very-plain') {
     return new FmtString(text, entities.length ? entities : undefined)
   }
 }
-
-const entityOffset =
-  (length: number) =>
-  (entity: MessageEntity): MessageEntity =>
-    Object.assign(entity, { offset: length + entity.offset })
-
 export const linkOrMention = (
   content: string | FmtString,
   data:
@@ -64,10 +58,7 @@ export const linkOrMention = (
     | { type: 'text_mention'; user: User }
 ) => {
   const text = content.toString()
-  const length = text.length
-  const elems = FmtString.normalise(content).entities || []
-  const entities = elems.map(entityOffset(length))
-  // insert to start of array
-  entities.unshift(Object.assign(data, { offset: 0, length }))
+  const entities = FmtString.normalise(content).entities || []
+  entities.unshift(Object.assign(data, { offset: 0, length: text.length }))
   return new FmtString(text, entities)
 }

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -1,6 +1,8 @@
 import { MessageEntity, User } from 'typegram'
 
 export class FmtString {
+  // to force parse_mode to become undefined when using FmtString
+  public parse_mode: undefined
   constructor(public text: string, public entities?: MessageEntity[]) {}
   static normalise(content: string | FmtString) {
     if (typeof content === 'string') return new FmtString(content, [])

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -7,9 +7,12 @@ export interface FmtString {
 }
 
 export class FmtString implements FmtString {
-  constructor(public text: string, public entities?: MessageEntity[]) {
-    // force parse_mode to undefined if entities are present
-    if (entities) this.parse_mode = undefined
+  constructor(public text: string, entities?: MessageEntity[]) {
+    if (entities) {
+      this.entities = entities
+      // force parse_mode to undefined if entities are present
+      this.parse_mode = undefined
+    }
   }
   static normalise(content: string | FmtString) {
     if (typeof content === 'string') return new FmtString(content)

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -1,0 +1,93 @@
+import { MessageEntity, User } from 'typegram'
+
+export class FmtString {
+  constructor(public text: string, public entities?: MessageEntity[]) {}
+  static normalise(content: string | FmtString) {
+    if (typeof content === 'string') return new FmtString(content, [])
+    return content
+  }
+  toString() {
+    return this.text
+  }
+}
+
+export namespace Types {
+  // prettier-ignore
+  export type Containers = 'bold' | 'italic' | 'spoiler' | 'strikethrough' | 'underline'
+  export type NonContainers = 'code' | 'pre'
+  export type Text = Containers | NonContainers
+}
+
+export namespace Fmts {
+  export interface Base {
+    type: string
+    content: string
+    children?: MessageEntity[]
+  }
+
+  export interface Text extends Base {
+    type: Types.Text
+  }
+
+  export interface Url extends Base {
+    type: 'text_link'
+    url: string
+  }
+
+  export interface Mention extends Base {
+    type: 'text_mention'
+    user: User
+  }
+}
+
+export type Fmts = Fmts.Text | Fmts.Url | Fmts.Mention
+
+export function fmt(parts: TemplateStringsArray, ...items: Fmts[]) {
+  let text = ''
+  const entities: MessageEntity[] = []
+  for (let i = 0; i < parts.length; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    text += parts[i]!
+    const item = items[i]
+    if (!item) continue
+    const { type, content } = item
+    const offset = text.length
+    const length = content.length
+    if (type === 'text_link')
+      entities.push({ type, offset, length, url: item.url })
+    else if (type === 'text_mention')
+      entities.push({ type, offset, length, user: item.user })
+    else entities.push({ type, offset, length })
+    if (item.children)
+      for (const child of item.children)
+        entities.push({ ...child, offset: child.offset + offset })
+    text += item.content
+  }
+  return new FmtString(text, entities.length ? entities : undefined)
+}
+
+interface fmtText {
+  (type: Types.NonContainers): (content: string) => Fmts
+  (type: Types.Containers): (content: string | FmtString | Fmts) => Fmts
+  (type: 'text_link'): (
+    content: string | FmtString | Fmts,
+    opts: { url: string }
+  ) => Fmts
+  (type: 'text_mention'): (
+    content: string | FmtString | Fmts,
+    opts: { user: User }
+  ) => Fmts
+}
+
+export const fmtText = ((type: Types.Text | 'text_link' | 'text_mention') =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (content: string | FmtString | Fmts, opts: any) => {
+    if (typeof content === 'string') return { type, content, ...opts }
+    else if (content instanceof FmtString) {
+      const { text, entities } = content
+      return { type, content: text, children: entities, ...opts }
+    } else {
+      const fmted = fmt`${content}`
+      return { type, content: fmted.text, children: fmted.entities, ...opts }
+    }
+  }) as fmtText

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -1,11 +1,18 @@
 import { MessageEntity, User } from 'typegram'
 
-export class FmtString {
-  // to force parse_mode to become undefined when using FmtString
-  public parse_mode: undefined
-  constructor(public text: string, public entities?: MessageEntity[]) {}
+export interface FmtString {
+  text: string
+  entities?: MessageEntity[]
+  parse_mode?: undefined
+}
+
+export class FmtString implements FmtString {
+  constructor(public text: string, public entities?: MessageEntity[]) {
+    // force parse_mode to undefined if entities are present
+    if (entities) this.parse_mode = undefined
+  }
   static normalise(content: string | FmtString) {
-    if (typeof content === 'string') return new FmtString(content, [])
+    if (typeof content === 'string') return new FmtString(content)
     return content
   }
   toString() {

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -15,9 +15,6 @@ export class FmtString implements FmtString {
     if (typeof content === 'string') return new FmtString(content)
     return content
   }
-  toString() {
-    return this.text
-  }
 }
 
 export namespace Types {
@@ -68,8 +65,7 @@ export const linkOrMention = (
     | { type: 'text_link'; url: string }
     | { type: 'text_mention'; user: User }
 ) => {
-  const text = content.toString()
-  const entities = FmtString.normalise(content).entities || []
+  const { text, entities = [] } = FmtString.normalise(content)
   entities.unshift(Object.assign(data, { offset: 0, length: text.length }))
   return new FmtString(text, entities)
 }

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -42,7 +42,10 @@ export namespace Fmts {
 
 export type Fmts = Fmts.Text | Fmts.Url | Fmts.Mention
 
-export function fmt(parts: TemplateStringsArray, ...items: Fmts[]) {
+export function fmt(
+  parts: TemplateStringsArray | string[],
+  ...items: (string | Fmts)[]
+) {
   let text = ''
   const entities: MessageEntity[] = []
   for (let i = 0; i < parts.length; i++) {
@@ -50,6 +53,10 @@ export function fmt(parts: TemplateStringsArray, ...items: Fmts[]) {
     text += parts[i]!
     const item = items[i]
     if (!item) continue
+    if (typeof item === 'string') {
+      text += item
+      continue
+    }
     const { type, content } = item
     const offset = text.length
     const length = content.length

--- a/src/core/helpers/formatting.ts
+++ b/src/core/helpers/formatting.ts
@@ -28,7 +28,11 @@ export function _fmt(
 export function _fmt(
   kind: Types.NonContainers
 ): (parts: TemplateParts, ...items: string[]) => FmtString
-export function _fmt(kind: Types.Text | 'very-plain') {
+export function _fmt(
+  kind: 'pre',
+  opts: { language: string }
+): (parts: TemplateParts, ...items: string[]) => FmtString
+export function _fmt(kind: Types.Text | 'very-plain', opts?: object) {
   return function fmt(parts: TemplateParts, ...items: (string | FmtString)[]) {
     let text = ''
     const entities: MessageEntity[] = []
@@ -47,7 +51,7 @@ export function _fmt(kind: Types.Text | 'very-plain') {
       text += item.text
     }
     if (kind !== 'very-plain')
-      entities.unshift({ type: kind, offset: 0, length: text.length })
+      entities.unshift({ type: kind, offset: 0, length: text.length, ...opts })
     return new FmtString(text, entities.length ? entities : undefined)
   }
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,18 +1,21 @@
 import { User } from 'typegram'
-import { type Fmts, FmtString, fmtText, fmt } from './core/helpers/formatting'
+import { FmtString, _fmt, linkOrMention } from './core/helpers/formatting'
 
-export { fmt, FmtString, Fmts }
+export { FmtString }
 
-export const bold = fmtText('bold')
-export const italic = fmtText('italic')
-export const spoiler = fmtText('spoiler')
-export const strikethrough = fmtText('strikethrough')
-export const underline = fmtText('underline')
-export const code = fmtText('code')
-export const pre = fmtText('pre')
-export const link = (content: string | FmtString | Fmts, url: string) =>
-  fmtText('text_link')(content, { url })
-export const mention = (name: string | FmtString | Fmts, user: number | User) =>
+export const fmt = _fmt('toplevel')
+export const bold = _fmt('bold')
+export const italic = _fmt('italic')
+export const spoiler = _fmt('spoiler')
+export const strikethrough = _fmt('strikethrough')
+export const underline = _fmt('underline')
+export const code = _fmt('code')
+export const pre = _fmt('pre')
+
+export const link = (content: string | FmtString, url: string) =>
+  linkOrMention(content, { type: 'text_link', url })
+
+export const mention = (name: string | FmtString, user: number | User) =>
   typeof user === 'number'
     ? link(name, 'tg://user?id=' + user)
-    : fmtText('text_mention')(name, { user })
+    : linkOrMention(name, { type: 'text_mention', user })

--- a/src/format.ts
+++ b/src/format.ts
@@ -10,7 +10,7 @@ export const spoiler = _fmt('spoiler')
 export const strikethrough = _fmt('strikethrough')
 export const underline = _fmt('underline')
 export const code = _fmt('code')
-export const pre = _fmt('pre')
+export const pre = (language: string) => _fmt('pre', { language })
 
 export const link = (content: string | FmtString, url: string) =>
   linkOrMention(content, { type: 'text_link', url })

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,18 @@
+import { User } from 'typegram'
+import { type Fmts, FmtString, fmtText, fmt } from './core/helpers/formatting'
+
+export { fmt, FmtString, Fmts }
+
+export const bold = fmtText('bold')
+export const italic = fmtText('italic')
+export const spoiler = fmtText('spoiler')
+export const strikethrough = fmtText('strikethrough')
+export const underline = fmtText('underline')
+export const code = fmtText('code')
+export const pre = fmtText('pre')
+export const link = (content: string | FmtString | Fmts, url: string) =>
+  fmtText('text_link')(content, { url })
+export const mention = (name: string | FmtString | Fmts, user: number | User) =>
+  typeof user === 'number'
+    ? link(name, 'tg://user?id=' + user)
+    : fmtText('text_mention')(name, { user })

--- a/src/format.ts
+++ b/src/format.ts
@@ -3,7 +3,7 @@ import { FmtString, _fmt, linkOrMention } from './core/helpers/formatting'
 
 export { FmtString }
 
-export const fmt = _fmt('toplevel')
+export const fmt = _fmt('very-plain')
 export const bold = _fmt('bold')
 export const italic = _fmt('italic')
 export const spoiler = _fmt('spoiler')

--- a/src/future.ts
+++ b/src/future.ts
@@ -14,7 +14,7 @@ function makeReply<
 const replyContext: ReplyContext = {
   replyWithChatAction: function () {
     throw new TypeError(
-      'ctx.replyWithChatAction is removed, use sendChatAction instead'
+      'ctx.replyWithChatAction has been removed, use ctx.sendChatAction instead'
     )
   },
   reply(this: Context, text, extra) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * as Types from './telegram-types'
 
 export * as Markup from './markup'
 export * as Input from './input'
+export * as Format from './format'
 
 export { deunionize } from './deunionize'
 export { session, MemorySessionStore } from './session'

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -1,5 +1,6 @@
 /** @format */
 
+import { Expand } from './util'
 import { Message, Opts, Telegram, Update } from './core/types/typegram'
 import { UnionKeys } from './deunionize'
 import { FmtString } from './format'
@@ -11,7 +12,7 @@ export type ChatAction = Opts<'sendChatAction'>['action']
 
 // Modify type so caption, if exists, can be FmtString
 type WrapCaption<T> = T extends { caption?: string }
-  ? Omit<T, 'caption'> & { caption?: string | FmtString }
+  ? Expand<Omit<T, 'caption'> & { caption?: string | FmtString }>
   : T
 
 // extra types

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -2,11 +2,17 @@
 
 import { Message, Opts, Telegram, Update } from './core/types/typegram'
 import { UnionKeys } from './deunionize'
+import { FmtString } from './format'
 
 export { Markup } from './markup'
 
 // tiny helper types
 export type ChatAction = Opts<'sendChatAction'>['action']
+
+// Modify type so caption, if exists, can be FmtString
+type WrapCaption<T> = T extends { caption?: string }
+  ? Omit<T, 'caption'> & { caption?: string | FmtString }
+  : T
 
 // extra types
 /**
@@ -17,7 +23,7 @@ export type ChatAction = Opts<'sendChatAction'>['action']
 type MakeExtra<
   M extends keyof Telegram,
   K extends keyof Omit<Opts<M>, 'chat_id'> = never
-> = Omit<Opts<M>, 'chat_id' | K>
+> = WrapCaption<Omit<Opts<M>, 'chat_id' | K>>
 
 export type ExtraAddStickerToSet = MakeExtra<
   'addStickerToSet',

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -3,6 +3,8 @@ import * as tt from './telegram-types'
 import ApiClient from './core/network/client'
 import { isAbsolute } from 'path'
 import { URL } from 'url'
+import { FmtString } from './format'
+import { fmtCaption } from './util'
 
 export class Telegram extends ApiClient {
   /**
@@ -129,10 +131,11 @@ export class Telegram extends ApiClient {
    */
   sendMessage(
     chatId: number | string,
-    text: string,
+    text: string | FmtString,
     extra?: tt.ExtraReplyMessage
   ) {
-    return this.callApi('sendMessage', { chat_id: chatId, text, ...extra })
+    const t = typeof text === 'string' ? new FmtString(text) : text
+    return this.callApi('sendMessage', { chat_id: chatId, ...extra, ...t })
   }
 
   /**
@@ -245,7 +248,11 @@ export class Telegram extends ApiClient {
     photo: tg.Opts<'sendPhoto'>['photo'],
     extra?: tt.ExtraPhoto
   ) {
-    return this.callApi('sendPhoto', { chat_id: chatId, photo, ...extra })
+    return this.callApi('sendPhoto', {
+      chat_id: chatId,
+      photo,
+      ...fmtCaption(extra),
+    })
   }
 
   /**
@@ -265,7 +272,11 @@ export class Telegram extends ApiClient {
     document: tg.Opts<'sendDocument'>['document'],
     extra?: tt.ExtraDocument
   ) {
-    return this.callApi('sendDocument', { chat_id: chatId, document, ...extra })
+    return this.callApi('sendDocument', {
+      chat_id: chatId,
+      document,
+      ...fmtCaption(extra),
+    })
   }
 
   /**
@@ -279,7 +290,11 @@ export class Telegram extends ApiClient {
     audio: tg.Opts<'sendAudio'>['audio'],
     extra?: tt.ExtraAudio
   ) {
-    return this.callApi('sendAudio', { chat_id: chatId, audio, ...extra })
+    return this.callApi('sendAudio', {
+      chat_id: chatId,
+      audio,
+      ...fmtCaption(extra),
+    })
   }
 
   /**
@@ -304,7 +319,11 @@ export class Telegram extends ApiClient {
     video: tg.Opts<'sendVideo'>['video'],
     extra?: tt.ExtraVideo
   ) {
-    return this.callApi('sendVideo', { chat_id: chatId, video, ...extra })
+    return this.callApi('sendVideo', {
+      chat_id: chatId,
+      video,
+      ...fmtCaption(extra),
+    })
   }
 
   /**
@@ -319,7 +338,7 @@ export class Telegram extends ApiClient {
     return this.callApi('sendAnimation', {
       chat_id: chatId,
       animation,
-      ...extra,
+      ...fmtCaption(extra),
     })
   }
 
@@ -348,7 +367,11 @@ export class Telegram extends ApiClient {
     voice: tg.Opts<'sendVoice'>['voice'],
     extra?: tt.ExtraVoice
   ) {
-    return this.callApi('sendVoice', { chat_id: chatId, voice, ...extra })
+    return this.callApi('sendVoice', {
+      chat_id: chatId,
+      voice,
+      ...fmtCaption(extra),
+    })
   }
 
   /**
@@ -1065,7 +1088,7 @@ export class Telegram extends ApiClient {
       chat_id: chatId,
       from_chat_id: fromChatId,
       message_id: messageId,
-      ...extra,
+      ...fmtCaption(extra),
     })
   }
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -791,15 +791,16 @@ export class Telegram extends ApiClient {
     chatId: number | string | undefined,
     messageId: number | undefined,
     inlineMessageId: string | undefined,
-    text: string,
+    text: string | FmtString,
     extra?: tt.ExtraEditMessageText
   ) {
+    const t = FmtString.normalise(text)
     return this.callApi('editMessageText', {
-      text,
       chat_id: chatId,
       message_id: messageId,
       inline_message_id: inlineMessageId,
       ...extra,
+      ...t,
     })
   }
 
@@ -816,15 +817,20 @@ export class Telegram extends ApiClient {
     chatId: number | string | undefined,
     messageId: number | undefined,
     inlineMessageId: string | undefined,
-    caption: string | undefined,
+    caption: string | FmtString | undefined,
     extra?: tt.ExtraEditMessageCaption
   ) {
+    // fmt may have entities (and parse_mode: undefined if entities are present)
+    const { text, ...fmt } = caption
+      ? FmtString.normalise(caption)
+      : { text: undefined }
     return this.callApi('editMessageCaption', {
-      caption,
+      caption: text,
       chat_id: chatId,
       message_id: messageId,
       inline_message_id: inlineMessageId,
       ...extra,
+      ...fmt,
     })
   }
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -134,7 +134,7 @@ export class Telegram extends ApiClient {
     text: string | FmtString,
     extra?: tt.ExtraReplyMessage
   ) {
-    const t = typeof text === 'string' ? new FmtString(text) : text
+    const t = FmtString.normalise(text)
     return this.callApi('sendMessage', { chat_id: chatId, ...extra, ...t })
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,8 +17,15 @@ export function fmtCaption<
 >(extra?: Extra): MaybeExtra<Extra> {
   const caption = extra?.caption
   if (!caption || typeof caption === 'string') return extra as MaybeExtra<Extra>
-  const { text, ...fmt } = caption
-  return { ...extra, caption: text, ...fmt }
+  const { text, entities } = caption
+  return {
+    ...extra,
+    caption: text,
+    ...(entities && {
+      caption_entities: entities,
+      parse_mode: undefined,
+    }),
+  }
 }
 
 export function deprecate(

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,12 @@ import { FmtString } from './format'
 
 export const env = process.env
 
+export type Expand<T> = T extends object
+  ? T extends infer O
+    ? { [K in keyof O]: O[K] }
+    : never
+  : T
+
 type MaybeExtra<Extra> = (Extra & { caption?: string }) | undefined
 
 export function fmtCaption<

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,12 +17,8 @@ export function fmtCaption<
 >(extra?: Extra): MaybeExtra<Extra> {
   const caption = extra?.caption
   if (!caption || typeof caption === 'string') return extra as MaybeExtra<Extra>
-  return {
-    ...extra,
-    caption: caption.text,
-    caption_entities: caption.entities,
-    parse_mode: undefined,
-  }
+  const { text, ...fmt } = caption
+  return { ...extra, caption: text, ...fmt }
 }
 
 export function deprecate(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,23 @@
+import { FmtString } from './format'
+
 export const env = process.env
+
+type MaybeExtra<Extra> = (Extra & { caption?: string }) | undefined
+
+export function fmtCaption<
+  Extra extends {
+    caption?: string | FmtString
+  } & Record<string, unknown>
+>(extra?: Extra): MaybeExtra<Extra> {
+  const caption = extra?.caption
+  if (!caption || typeof caption === 'string') return extra as MaybeExtra<Extra>
+  return {
+    ...extra,
+    caption: caption.text,
+    caption_entities: caption.entities,
+    parse_mode: undefined,
+  }
+}
 
 export function deprecate(
   method: string,


### PR DESCRIPTION
Ref: [related conversation](https://t.me/TelegrafJSChat/83737)

Formatting is often troublesome, especially if you have many characters that need escaping. Escaping is messy, and it is much cleaner to create entities instead, but there were no utils to help with this in Telegraf so far. This PR adds support for `telegraf/format`. To be used like this:

```TS
import { fmt, bold, italic, underline, mention, link } from "telegraf/format";

ctx.reply(fmt`
Ground control to ${mention("Major Tom", 10000000)}
${bold`Lock your Soyuz hatch`} and ${italic`put your helmet on`}

— ${link(underline`David Bowie`), "https://en.wikipedia.org/wiki/David_Bowie")}
`);
```

This also just works with captions!

```TS
ctx.replyWithPhoto(
  file.id,
  { caption: fmt`${bold`File name:`} ${file.name}` },
);
```

For the future: `emoji()` may be a nice addition to formatting; however emojibase is quite large and would not be a suitable dependency for telegraf. Creating a separate `@telegraf/format-emoji` package could work.