### PR TITLE
Add telegraf/update, useful for narrowing custom Context

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
         "@typescript-eslint/no-explicit-any": "warn",
         "@typescript-eslint/no-non-null-assertion": "warn",
         "@typescript-eslint/promise-function-async": "off",
+        "@typescript-eslint/no-namespace": "off",
         "no-undef": "off"
       }
     }

--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,8 @@
     "/docs/",
     "/test/",
     "/types.*",
-    "/future.*"
+    "/future.*",
+    "/update.*"
   ],
   "reportUnusedDisableDirectives": true,
   "plugins": ["ava"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telegraf",
-  "version": "4.9.0",
+  "version": "4.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "telegraf",
-      "version": "4.9.0",
+      "version": "4.9.2",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "types": "./types.d.ts",
       "require": "./types.js",
       "import": "./types.js"
+    },
+    "./update": {
+      "types": "./update.d.ts",
+      "require": "./update.js",
+      "import": "./update.js"
     }
   },
   "files": [

--- a/release-notes/4.10.0.md
+++ b/release-notes/4.10.0.md
@@ -2,3 +2,18 @@
 
 * Deprecated `ctx.replyWithMarkdown`; prefer MarkdownV2 as Telegram recommends.
 * `bot.launch()` webhook options now accepts `certificate` for self-signed certs.
+* Added new export `"telegraf/update"`, used to narrow user contexts as such:
+  ```TS
+  import { Update } from "telegraf/update";
+
+  interface MyCtx<U extends Update = Update> extends Context<U> {
+    session: { count: number }
+  }
+
+  const actionHandler = (ctx: MyCtx<Update.CallbackQuery>) => { ... };
+  const textHandler = (ctx: MyCtx<Update.Message.Text>) => { ... };
+
+  bot.action("click", actionHandler);
+  bot.on("text", textHandler);
+  ```
+  This could replace internally used `MatchedContext<>` as well in v5.

--- a/release-notes/4.10.0.md
+++ b/release-notes/4.10.0.md
@@ -3,17 +3,19 @@
 * Deprecated `ctx.replyWithMarkdown`; prefer MarkdownV2 as Telegram recommends.
 * `bot.launch()` webhook options now accepts `certificate` for self-signed certs.
 * Added new export `"telegraf/update"`, used to narrow user contexts as such:
+
   ```TS
-  import { Update } from "telegraf/update";
+  import { Update, Message } from "telegraf/update";
 
   interface MyCtx<U extends Update = Update> extends Context<U> {
     session: { count: number }
   }
 
   const actionHandler = (ctx: MyCtx<Update.CallbackQuery>) => { ... };
-  const textHandler = (ctx: MyCtx<Update.Message.Text>) => { ... };
+  const textHandler = (ctx: MyCtx<Update.Message<Message.TextMessage>>) => { ... };
 
   bot.action("click", actionHandler);
   bot.on("text", textHandler);
   ```
+
   This could replace internally used `MatchedContext<>` as well in v5.

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,6 +4,7 @@ import { Deunionize, PropOr, UnionKeys } from './deunionize'
 import ApiClient from './core/network/client'
 import { deprecate } from './util'
 import Telegram from './telegram'
+import { Update } from './update'
 
 type Tail<T> = T extends [unknown, ...infer U] ? U : never
 
@@ -11,7 +12,7 @@ type Shorthand<FName extends Exclude<keyof Telegram, keyof ApiClient>> = Tail<
   Parameters<Telegram[FName]>
 >
 
-export class Context<U extends Deunionize<tg.Update> = tg.Update> {
+export class Context<U extends Deunionize<Update.All> = Update.All> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly state: Record<string | symbol, any> = {}
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,7 +12,7 @@ type Shorthand<FName extends Exclude<keyof Telegram, keyof ApiClient>> = Tail<
   Parameters<Telegram[FName]>
 >
 
-export class Context<U extends Deunionize<Update.All> = Update.All> {
+export class Context<U extends Deunionize<Update> = Update> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly state: Record<string | symbol, any> = {}
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,163 @@
+import { Update as U, Message as M } from './core/types/typegram'
+
+/**
+ * Update types to use with `Context<Update>`.
+ * The exact structure of this export may change in the future, or be removed entirely.
+ * @experimental
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Update {
+  export interface Message extends U.MessageUpdate {}
+  export interface EditedMessage extends U.EditedMessageUpdate {}
+  export interface ChannelPost extends U.ChannelPostUpdate {}
+  export interface EditedChannelPost extends U.EditedChannelPostUpdate {}
+  export interface InlineQuery extends U.InlineQueryUpdate {}
+  export interface ChosenInlineResult extends U.ChosenInlineResultUpdate {}
+  export interface CallbackQuery extends U.CallbackQueryUpdate {}
+  export interface ShippingQuery extends U.ShippingQueryUpdate {}
+  export interface PreCheckoutQuery extends U.PreCheckoutQueryUpdate {}
+  export interface Poll extends U.PollUpdate {}
+  export interface PollAnswer extends U.PollAnswerUpdate {}
+  export interface MyChatMember extends U.MyChatMemberUpdate {}
+  export interface ChatMember extends U.ChatMemberUpdate {}
+  export interface ChatJoinRequest extends U.ChatJoinRequestUpdate {}
+
+  export type All =
+    | Message
+    | EditedMessage
+    | ChannelPost
+    | EditedChannelPost
+    | InlineQuery
+    | ChosenInlineResult
+    | CallbackQuery
+    | ShippingQuery
+    | PreCheckoutQuery
+    | Poll
+    | PollAnswer
+    | MyChatMember
+    | ChatMember
+    | ChatJoinRequest
+
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace Message {
+    export type Text = Message & {
+      message: M.TextMessage
+    }
+    export type Captionable = Message & {
+      message: M.CaptionableMessage
+    }
+    export type Media = Message & {
+      message: M.MediaMessage
+    }
+    export type Audio = Message & {
+      message: M.AudioMessage
+    }
+    export type Document = Message & {
+      message: M.DocumentMessage
+    }
+    export type Animation = Message & {
+      message: M.AnimationMessage
+    }
+    export type Photo = Message & {
+      message: M.PhotoMessage
+    }
+    export type Sticker = Message & {
+      message: M.StickerMessage
+    }
+    export type Video = Message & {
+      message: M.VideoMessage
+    }
+    export type VideoNote = Message & {
+      message: M.VideoNoteMessage
+    }
+    export type Voice = Message & {
+      message: M.VoiceMessage
+    }
+    export type Contact = Message & {
+      message: M.ContactMessage
+    }
+    export type Dice = Message & {
+      message: M.DiceMessage
+    }
+    export type Game = Message & {
+      message: M.GameMessage
+    }
+    export type Poll = Message & {
+      message: M.PollMessage
+    }
+    export type Location = Message & {
+      message: M.LocationMessage
+    }
+    export type Venue = Message & {
+      message: M.VenueMessage
+    }
+    export type NewChatMembers = Message & {
+      message: M.NewChatMembersMessage
+    }
+    export type LeftChatMember = Message & {
+      message: M.LeftChatMemberMessage
+    }
+    export type NewChatTitle = Message & {
+      message: M.NewChatTitleMessage
+    }
+    export type NewChatPhoto = Message & {
+      message: M.NewChatPhotoMessage
+    }
+    export type DeleteChatPhoto = Message & {
+      message: M.DeleteChatPhotoMessage
+    }
+    export type GroupChatCreated = Message & {
+      message: M.GroupChatCreatedMessage
+    }
+    export type SupergroupChat = Message & {
+      message: M.SupergroupChatCreated
+    }
+    export type ChannelChatCreated = Message & {
+      message: M.ChannelChatCreatedMessage
+    }
+    export type MessageAutoDeleteTimerChanged = Message & {
+      message: M.MessageAutoDeleteTimerChangedMessage
+    }
+    export type MigrateToChatId = Message & {
+      message: M.MigrateToChatIdMessage
+    }
+    export type MigrateFromChatId = Message & {
+      message: M.MigrateFromChatIdMessage
+    }
+    export type PinnedMessage = Message & {
+      message: M.PinnedMessageMessage
+    }
+    export type Invoice = Message & {
+      message: M.InvoiceMessage
+    }
+    export type SuccessfulPayment = Message & {
+      message: M.SuccessfulPaymentMessage
+    }
+    export type ConnectedWebsite = Message & {
+      message: M.ConnectedWebsiteMessage
+    }
+    export type PassportData = Message & {
+      message: M.PassportDataMessage
+    }
+    export type ProximityAlertTriggered = Message & {
+      message: M.ProximityAlertTriggeredMessage
+    }
+    export type VideoChatScheduled = Message & {
+      message: M.VideoChatScheduledMessage
+    }
+    export type VideoChatStarted = Message & {
+      message: M.VideoChatStartedMessage
+    }
+    export type VideoChatEnded = Message & {
+      message: M.VideoChatEndedMessage
+    }
+    export type VideoChatParticipantsInvited = Message & {
+      message: M.VideoChatParticipantsInvitedMessage
+    }
+    export type WebAppData = Message & {
+      message: M.WebAppDataMessage
+    }
+  }
+}
+
+export type Update = Update.All

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,16 +1,84 @@
-import { Update as U, Message as M } from './core/types/typegram'
+import {
+  Update as U,
+  Message as Msg,
+  CommonMessageBundle as CommonMsg,
+} from './core/types/typegram'
 
 /**
- * Update types to use with `Context<Update>`.
+ * Update types to narrow Context.
  * The exact structure of this export may change in the future, or be removed entirely.
+ *
+ * Usage:
+ *
+ * ```TS
+ * interface MyCtx<U extends Update = Update> extends Context<U> {
+ *   session: { count: number }
+ * }
+ *
+ * const actionHandler = (ctx: MyCtx<Update.CallbackQuery>) => {...};
+ * bot.action("forward", actionHandler);
+ *
+ * const textHandler = (ctx: MyCtx<Update.Message<Message.Text>>) => {...};
+ * bot.on("text", textHandler);
+ *
+ * const editedMessageHandler = (ctx: MyCtx<Update.EditedMessage>) => {...};
+ * bot.on("edited_message", editedMessageHandler);
+ * ```
  * @experimental
  */
-// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Update {
-  export interface Message extends U.MessageUpdate {}
-  export interface EditedMessage extends U.EditedMessageUpdate {}
-  export interface ChannelPost extends U.ChannelPostUpdate {}
-  export interface EditedChannelPost extends U.EditedChannelPostUpdate {}
+  /**
+   * Represents a Message update. This can be further narrowed down:
+   *
+   * ```TS
+   * type AnyMsg = Update.Message;
+   * type TextMsg = Update.Message<Message.TextMessage>;
+   * type AudioMsg = Update.Message<Message.AudioMessage>;
+   * ```
+   */
+  export type Message<Type extends Msg = Msg> =
+    // Choose specific Message sub-type
+    U.MessageUpdate & { message: Type }
+
+  /**
+   * Represents an Edited Message update. This can be further narrowed down:
+   *
+   * ```TS
+   * type AnyMsg = Update.EditedMessage;
+   * type TextMsg = Update.EditedMessage<Message.TextMessage>;
+   * type AudioMsg = Update.EditedMessage<Message.AudioMessage>;
+   * ```
+   */
+  export type EditedMessage<Type extends CommonMsg = CommonMsg> =
+    // Can only be a Common Message sub-type, no Service Messages
+    U.EditedMessageUpdate & { edited_message: Type }
+
+  /**
+   * Represents a Channel Post update. This can be further narrowed down:
+   *
+   * ```TS
+   * type AnyPost = Update.ChannelPost;
+   * type TextPost = Update.ChannelPost<Message.TextMessage>;
+   * type AudioPost = Update.ChannelPost<Message.AudioMessage>;
+   * ```
+   */
+  export type ChannelPost<Type extends Msg = Msg> =
+    // Choose specific Message sub-type
+    U.ChannelPostUpdate & { channel_post: Type }
+
+  /**
+   * Represents an Edited ChannelPost update. This can be further narrowed down:
+   *
+   * ```TS
+   * type AnyPost = Update.EditedChannelPost;
+   * type TextPost = Update.EditedChannelPost<Message.TextMessage>;
+   * type AudioPost = Update.EditedChannelPost<Message.AudioMessage>;
+   * ```
+   */
+  export type EditedChannelPost<Type extends CommonMsg = CommonMsg> =
+    // Can only be a Common Message sub-type, no Service Messages
+    U.EditedChannelPostUpdate & { edited_channel_post: Type }
+
   export interface InlineQuery extends U.InlineQueryUpdate {}
   export interface ChosenInlineResult extends U.ChosenInlineResultUpdate {}
   export interface CallbackQuery extends U.CallbackQueryUpdate {}
@@ -21,143 +89,20 @@ export namespace Update {
   export interface MyChatMember extends U.MyChatMemberUpdate {}
   export interface ChatMember extends U.ChatMemberUpdate {}
   export interface ChatJoinRequest extends U.ChatJoinRequestUpdate {}
-
-  export type All =
-    | Message
-    | EditedMessage
-    | ChannelPost
-    | EditedChannelPost
-    | InlineQuery
-    | ChosenInlineResult
-    | CallbackQuery
-    | ShippingQuery
-    | PreCheckoutQuery
-    | Poll
-    | PollAnswer
-    | MyChatMember
-    | ChatMember
-    | ChatJoinRequest
-
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  export namespace Message {
-    export type Text = Message & {
-      message: M.TextMessage
-    }
-    export type Captionable = Message & {
-      message: M.CaptionableMessage
-    }
-    export type Media = Message & {
-      message: M.MediaMessage
-    }
-    export type Audio = Message & {
-      message: M.AudioMessage
-    }
-    export type Document = Message & {
-      message: M.DocumentMessage
-    }
-    export type Animation = Message & {
-      message: M.AnimationMessage
-    }
-    export type Photo = Message & {
-      message: M.PhotoMessage
-    }
-    export type Sticker = Message & {
-      message: M.StickerMessage
-    }
-    export type Video = Message & {
-      message: M.VideoMessage
-    }
-    export type VideoNote = Message & {
-      message: M.VideoNoteMessage
-    }
-    export type Voice = Message & {
-      message: M.VoiceMessage
-    }
-    export type Contact = Message & {
-      message: M.ContactMessage
-    }
-    export type Dice = Message & {
-      message: M.DiceMessage
-    }
-    export type Game = Message & {
-      message: M.GameMessage
-    }
-    export type Poll = Message & {
-      message: M.PollMessage
-    }
-    export type Location = Message & {
-      message: M.LocationMessage
-    }
-    export type Venue = Message & {
-      message: M.VenueMessage
-    }
-    export type NewChatMembers = Message & {
-      message: M.NewChatMembersMessage
-    }
-    export type LeftChatMember = Message & {
-      message: M.LeftChatMemberMessage
-    }
-    export type NewChatTitle = Message & {
-      message: M.NewChatTitleMessage
-    }
-    export type NewChatPhoto = Message & {
-      message: M.NewChatPhotoMessage
-    }
-    export type DeleteChatPhoto = Message & {
-      message: M.DeleteChatPhotoMessage
-    }
-    export type GroupChatCreated = Message & {
-      message: M.GroupChatCreatedMessage
-    }
-    export type SupergroupChat = Message & {
-      message: M.SupergroupChatCreated
-    }
-    export type ChannelChatCreated = Message & {
-      message: M.ChannelChatCreatedMessage
-    }
-    export type MessageAutoDeleteTimerChanged = Message & {
-      message: M.MessageAutoDeleteTimerChangedMessage
-    }
-    export type MigrateToChatId = Message & {
-      message: M.MigrateToChatIdMessage
-    }
-    export type MigrateFromChatId = Message & {
-      message: M.MigrateFromChatIdMessage
-    }
-    export type PinnedMessage = Message & {
-      message: M.PinnedMessageMessage
-    }
-    export type Invoice = Message & {
-      message: M.InvoiceMessage
-    }
-    export type SuccessfulPayment = Message & {
-      message: M.SuccessfulPaymentMessage
-    }
-    export type ConnectedWebsite = Message & {
-      message: M.ConnectedWebsiteMessage
-    }
-    export type PassportData = Message & {
-      message: M.PassportDataMessage
-    }
-    export type ProximityAlertTriggered = Message & {
-      message: M.ProximityAlertTriggeredMessage
-    }
-    export type VideoChatScheduled = Message & {
-      message: M.VideoChatScheduledMessage
-    }
-    export type VideoChatStarted = Message & {
-      message: M.VideoChatStartedMessage
-    }
-    export type VideoChatEnded = Message & {
-      message: M.VideoChatEndedMessage
-    }
-    export type VideoChatParticipantsInvited = Message & {
-      message: M.VideoChatParticipantsInvitedMessage
-    }
-    export type WebAppData = Message & {
-      message: M.WebAppDataMessage
-    }
-  }
 }
 
-export type Update = Update.All
+export type Update =
+  | Update.Message
+  | Update.EditedMessage
+  | Update.ChannelPost
+  | Update.EditedChannelPost
+  | Update.InlineQuery
+  | Update.ChosenInlineResult
+  | Update.CallbackQuery
+  | Update.ShippingQuery
+  | Update.PreCheckoutQuery
+  | Update.Poll
+  | Update.PollAnswer
+  | Update.MyChatMember
+  | Update.ChatMember
+  | Update.ChatJoinRequest

--- a/update.d.ts
+++ b/update.d.ts
@@ -1,0 +1,1 @@
+export * from './typings/update'

--- a/update.js
+++ b/update.js
@@ -1,0 +1,3 @@
+// Just an empty export to allow eslint to think there's an actual module here
+// types.d.ts is the file we actually want to import
+module.exports = {}


### PR DESCRIPTION
Added new export `"telegraf/update"`, used to narrow user contexts as such:

```TS
import { Update, Message } from "telegraf/update";

interface MyCtx<U extends Update = Update> extends Context<U> {
	session: { count: number }
}

const actionHandler = (ctx: MyCtx<Update.CallbackQuery>) => { ... };
const textHandler = (ctx: MyCtx<Update.Message<Message.TextMessage>>) => { ... };

bot.action("click", actionHandler);
bot.on("text", textHandler);
```

This could replace internally used `MatchedContext<>` as well in v5.

Edit: updated example after making `Update.{Message|EditedMessage|ChannelPost|EditedChannelPost}` generic.