### PR TITLE
[Documentation] Changed wrong link to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ createServer(tlsOptions, await bot.createWebhook({ domain: "example.com" })).lis
 - [Google Cloud Functions example integration](https://github.com/feathers-studio/telegraf-docs/blob/master/examples/functions/google-cloud-function.ts)
 - [`express` example integration](https://github.com/feathers-studio/telegraf-docs/blob/master/examples/webhook/express.ts)
 - [`fastify` example integration](https://github.com/feathers-studio/telegraf-docs/blob/master/examples/webhook/fastify.ts)
-- [`koa` example integration](https://github.com/feathers-studio/telegraf-docs/blob/master/examples/webhook/fastify.ts)
+- [`koa` example integration](https://github.com/feathers-studio/telegraf-docs/blob/master/examples/webhook/koa.ts)
 - [NestJS framework integration module](https://github.com/bukhalo/nestjs-telegraf)
 - [Cloudflare Workers integration module](https://github.com/Tsuk1ko/cfworker-middware-telegraf)
 - Use [`bot.handleUpdate`](https://telegraf.js.org/classes/Telegraf-1.html#handleupdate) to write new integrations


### PR DESCRIPTION
# Description
The README for the project had the link for the fastify example twice, once for the fastify item and the other for the koa item. I'm just replacing the link to the koa example. I decided to quickly make a PR with the change.

## Type of change
- Documentation (typos, code examples or any documentation update)

# How Has This Been Tested?
No testing is necessary

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ Not required 
