### PR TITLE
InputFile helpers

### DIFF
--- a/release-notes/4.10.0.md
+++ b/release-notes/4.10.0.md
@@ -2,3 +2,19 @@
 
 * Deprecated `ctx.replyWithMarkdown`; prefer MarkdownV2 as Telegram recommends.
 * `bot.launch()` webhook options now accepts `certificate` for self-signed certs.
+* Added Input helpers to create the InputFile object.
+
+  ```TS
+  import { Telegraf, Input } from "telegraf";
+  const bot = new Telegraf(token);
+
+  bot.telegram.sendVideo(chatId, Input.fromLocalFile("../assets/cats.mp4"));
+
+  bot.telegram.sendDocument(chatId, Input.fromBuffer(buf));
+
+  bot.command("cat", ctx => {
+    ctx.sendPhoto(Input.fromURL("https://funny-cats.example/cats.jpg"))
+  });
+  ```
+
+  This helps clear the confusion many users have about InputFile, and provides a layer of abstraction that can be used in the future to declutter telegraf/client from having to handle all combinations of InputFile.

--- a/src/core/types/typegram.ts
+++ b/src/core/types/typegram.ts
@@ -14,12 +14,15 @@ export * from 'typegram/update'
 // telegraf input file definition
 interface InputFileByPath {
   source: string
+  filename?: string
 }
 interface InputFileByReadableStream {
   source: NodeJS.ReadableStream
+  filename?: string
 }
 interface InputFileByBuffer {
   source: Buffer
+  filename?: string
 }
 interface InputFileByURL {
   url: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { Telegram } from './telegram'
 export * as Types from './telegram-types'
 
 export * as Markup from './markup'
+export * as Input from './input'
 
 export { deunionize } from './deunionize'
 export { session, MemorySessionStore } from './session'

--- a/src/input.ts
+++ b/src/input.ts
@@ -5,14 +5,16 @@ import { InputFile } from './core/types/typegram'
  *
  * 10 MB max size for photos, 50 MB for other files.
  */
-export const fromLocalFile = (path: string): InputFile => ({ source: path })
+// prettier-ignore
+export const fromLocalFile = (path: string, filename?: string): InputFile => ({ source: path, filename })
 
 /**
  * The buffer will be uploaded as file to Telegram using multipart/form-data.
  *
  * 10 MB max size for photos, 50 MB for other files.
  */
-export const fromBuffer = (buffer: Buffer): InputFile => ({ source: buffer })
+// prettier-ignore
+export const fromBuffer = (buffer: Buffer, filename?: string): InputFile => ({ source: buffer, filename })
 
 /**
  * Contents of the stream will be uploaded as file to Telegram using multipart/form-data.
@@ -20,7 +22,7 @@ export const fromBuffer = (buffer: Buffer): InputFile => ({ source: buffer })
  * 10 MB max size for photos, 50 MB for other files.
  */
 // prettier-ignore
-export const fromReadableStream = (stream: NodeJS.ReadableStream): InputFile => ({ source: stream })
+export const fromReadableStream = (stream: NodeJS.ReadableStream, filename?: string): InputFile => ({ source: stream, filename })
 
 /**
  * Provide Telegram with an HTTP URL for the file to be sent.

--- a/src/input.ts
+++ b/src/input.ts
@@ -36,7 +36,7 @@ export const fromReadableStream = (stream: NodeJS.ReadableStream, filename?: str
  * 5 MB max size for photos and 20 MB max for other types of content.
  */
 // prettier-ignore
-export const fromURL = (url: string, filename?: string): InputFile => ({ url, filename })
+export const fromURL = (url: string | URL, filename?: string): InputFile => ({ url: url.toString(), filename })
 
 /**
  * If the file is already stored somewhere on the Telegram servers, you don't need to reupload it:

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,0 +1,50 @@
+import { InputFile } from './core/types/typegram'
+
+/**
+ * The local file specified by path will be uploaded to Telegram using multipart/form-data.
+ *
+ * 10 MB max size for photos, 50 MB for other files.
+ */
+export const fromLocalFile = (path: string): InputFile => ({ source: path })
+
+/**
+ * The buffer will be uploaded as file to Telegram using multipart/form-data.
+ *
+ * 10 MB max size for photos, 50 MB for other files.
+ */
+export const fromBuffer = (buffer: Buffer): InputFile => ({ source: buffer })
+
+/**
+ * Contents of the stream will be uploaded as file to Telegram using multipart/form-data.
+ *
+ * 10 MB max size for photos, 50 MB for other files.
+ */
+// prettier-ignore
+export const fromReadableStream = (stream: NodeJS.ReadableStream): InputFile => ({ source: stream })
+
+/**
+ * Provide Telegram with an HTTP URL for the file to be sent.
+ * Telegram will download and send the file.
+ *
+ * * The target file must have the correct MIME type (e.g., audio/mpeg for `sendAudio`, etc.).
+ * * `sendDocument` with URL will currently only work for GIF, PDF and ZIP files.
+ * * To use `sendVoice`, the file must have the type audio/ogg and be no more than 1MB in size.
+ * 1-20MB voice notes will be sent as files.
+ *
+ * 5 MB max size for photos and 20 MB max for other types of content.
+ */
+// prettier-ignore
+export const fromURL = (url: string, filename?: string): InputFile => ({ url, filename })
+
+/**
+ * If the file is already stored somewhere on the Telegram servers, you don't need to reupload it:
+ * each file object has a file_id field, simply pass this file_id as a parameter instead of uploading.
+ *
+ * It is not possible to change the file type when resending by file_id.
+ *
+ * It is not possible to resend thumbnails using file_id.
+ * They have to be uploaded using one of the other Input methods.
+ *
+ * There are no limits for files sent this way.
+ */
+export const fromFileId = (fileId: string): string => fileId

--- a/src/input.ts
+++ b/src/input.ts
@@ -25,6 +25,14 @@ export const fromBuffer = (buffer: Buffer, filename?: string): InputFile => ({ s
 export const fromReadableStream = (stream: NodeJS.ReadableStream, filename?: string): InputFile => ({ source: stream, filename })
 
 /**
+ * Contents of the URL will be streamed to Telegram.
+ *
+ * 10 MB max size for photos, 50 MB for other files.
+ */
+// prettier-ignore
+export const fromURLStream = (url: string | URL, filename?: string): InputFile => ({ url: url.toString(), filename })
+
+/**
  * Provide Telegram with an HTTP URL for the file to be sent.
  * Telegram will download and send the file.
  *
@@ -35,8 +43,7 @@ export const fromReadableStream = (stream: NodeJS.ReadableStream, filename?: str
  *
  * 5 MB max size for photos and 20 MB max for other types of content.
  */
-// prettier-ignore
-export const fromURL = (url: string | URL, filename?: string): InputFile => ({ url: url.toString(), filename })
+export const fromURL = (url: string | URL): string => url.toString()
 
 /**
  * If the file is already stored somewhere on the Telegram servers, you don't need to reupload it:


### PR DESCRIPTION
Input helpers to create the InputFile object.

```TS
import { Telegraf, Input } from "telegraf";
const bot = new Telegraf(token);

bot.telegram.sendVideo(chatId, Input.fromLocalFile("../assets/cats.mp4"));

bot.telegram.sendDocument(chatId, Input.fromBuffer(buf));

bot.command("cat", ctx => {
  return ctx.sendPhoto(Input.fromURL("https://funny-cats.example/cats.jpg"))
});
```

This helps clear the confusion many users have about InputFile, and provides a layer of abstraction that can be used in the future to declutter telegraf/client from having to handle all combinations of InputFile.