### PR TITLE
Resist session race conditions using reference counting

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,17 @@
     "build": "tsc",
     "build:docs": "typedoc src/index.ts",
     "pretest": "npm run build",
-    "test": "ava test/*",
+    "test": "ava",
     "lint": "eslint .",
     "checks": "npm test && npm run lint",
     "refresh": "npm run clean && npm ci",
     "clean": "git clean -fX .eslintcache docs/build/ lib/ typings/"
+  },
+  "ava": {
+    "files": [
+      "test/*",
+      "!test/_*"
+    ]
   },
   "type": "commonjs",
   "engines": {

--- a/release-notes/4.12.0.md
+++ b/release-notes/4.12.0.md
@@ -1,5 +1,23 @@
 # 4.12.0
 
+Normally the most exciting features of a new release would be support for the latest Bot API. But in this update, it's session! This has been in the works for many months, and we're happy to bring it to you this release!
+
+## Stable session
+
+Some of you may know that builtin session has been deprecated for quite a while. This was motivated by the fact that session is prone to race-conditions ([#1372](https://github.com/telegraf/telegraf/issues/1372)). This left the community in a grey area where they continued to use session despite the deprecation, since no clear alternative was provided. Added to this was the fact that there were no official database-backed sessions, and all unofficial async session middleware were affected by [#1372](https://github.com/telegraf/telegraf/issues/1372).
+
+This release finally addresses both of these long-running issues.
+
+### No more race conditions
+
+[#1713](https://github.com/telegraf/telegraf/pull/1713) provides a reference-counted implementation resistant to race conditions. Session is now no longer deprecated, and can be used safely!
+
+> Note: You should read more about how to safely use session in the [docs repo](https://github.com/feathers-studio/telegraf-docs/blob/b694bcc36b4f71fb1cd650a345c2009ab4d2a2a5/guide/session.md).
+
+### Official database adapters are here!
+
+We're also happy to announce a revamped [`@telegraf/session`](https://github.com/telegraf/session)—this provides official store implementations for database-backed sessions via Redis, MongoDB, MySQL, MariaDB, PostgreSQL, and SQLite. Just install the drivers necessary for your database, and off you go! Since this package now only provides a `store` implementation, it's usable with builtin session, and effectively makes all implementations have the same safety as the core package. [Check it out!](https://github.com/telegraf/session)
+
 ## Bot API 6.5 support
 
 - Updated Typegram, added the following Markup.button helpers to request a user or chat:

--- a/release-notes/4.12.0.md
+++ b/release-notes/4.12.0.md
@@ -18,23 +18,39 @@ This release finally addresses both of these long-running issues.
 
 We're also happy to announce a revamped [`@telegraf/session`](https://github.com/telegraf/session)—this provides official store implementations for database-backed sessions via Redis, MongoDB, MySQL, MariaDB, PostgreSQL, and SQLite. Just install the drivers necessary for your database, and off you go! Since this package now only provides a `store` implementation, it's usable with builtin session, and effectively makes all implementations have the same safety as the core package. [Check it out!](https://github.com/telegraf/session)
 
+### Default session
+
+Additionally, session now accepts a `defaultSession` parameter. You no longer need a hacky middleware to do `ctx.session ??= { count }`.
+
+```TS
+// 🤢 Old way
+bot.use(session());
+bot.use((ctx, next) => {
+  ctx.session ??= { count: 0 };
+  return next();
+});
+
+// 😁 New way ✅
+bot.use(session({ defaultSession: () => ({ count: 0 }) }));
+```
+
 ## Bot API 6.5 support
 
 - Updated Typegram, added the following Markup.button helpers to request a user or chat:
-  - `Markup.button.userRequest`
-  - `Markup.button.botRequest`
-  - `Markup.button.groupRequest`
-  - `Markup.button.channelRequest`
+- `Markup.button.userRequest`
+- `Markup.button.botRequest`
+- `Markup.button.groupRequest`
+- `Markup.button.channelRequest`
 - `Telegram::setChatPermissions` and `Context::setChatPermissions` accept a new parameter for `{ use_independent_chat_permissions?: boolean }` as documented in the [API](https://core.telegram.org/bots/api#setchatpermissions).
 
 ## Bot API 6.4 support
 
 - Updated Typegram, added the following new methods to class `Telegram` and `Context`:
-  - `editGeneralForumTopic`
-  - `closeGeneralForumTopic`
-  - `reopenGeneralForumTopic`
-  - `hideGeneralForumTopic`
-  - `unhideGeneralForumTopic`
+- `editGeneralForumTopic`
+- `closeGeneralForumTopic`
+- `reopenGeneralForumTopic`
+- `hideGeneralForumTopic`
+- `unhideGeneralForumTopic`
 - `Context::sendChatAction` will automatically infer `message_thread_id` for topic messages.
 - Fix for `'this' Context of type 'NarrowedContext' is not assignable to method's 'this' of type 'Context<Update>'`.
 
@@ -42,16 +58,16 @@ We're also happy to announce a revamped [`@telegraf/session`](https://github.com
 
 - New `join` fmt helper to combine dynamic arrays into a single FmtString.
 
-  ```TS
-  import { fmt, bold, join } from "telegraf/format";
+```TS
+import { fmt, bold, join } from "telegraf/format";
 
-  // elsewhere
-  bot.command("/fruits", ctx => {
-    const array = ["Oranges", "Apples", "Grapes"];
-    const fruitList = join(array.map(fruit => bold(fruit)), "\n");
-    const msg = fmt`Fruits to buy:\n${fruitList}`;
-    ctx.sendMessage(msg);
-  });
-  ```
+// elsewhere
+bot.command("/fruits", ctx => {
+  const array = ["Oranges", "Apples", "Grapes"];
+  const fruitList = join(array.map(fruit => bold(fruit)), "\n");
+  const msg = fmt`Fruits to buy:\n${fruitList}`;
+  ctx.sendMessage(msg);
+});
+```
 
 - Fixed various bugs in fmt helpers, so things like `bold(italic("telegraf"))` will now work as expected.

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,9 +11,8 @@ export interface SessionStore<T> {
 }
 
 interface SessionOptions<S extends object> {
-  initial?: () => S
-  store?: SessionStore<S>
   getSessionKey?: (ctx: Context) => Promise<string | undefined>
+  store?: SessionStore<S>
 }
 
 export interface SessionContext<S extends object> extends Context {

--- a/src/session.ts
+++ b/src/session.ts
@@ -78,12 +78,16 @@ export function session<S extends object>(
       debug(`(${updId}) updating cache`)
       // another request may have beaten us to the punch
       const c = cache.get(key)
-      // (1) preserve cached reference using Object.assign, or create new object if it doesn't exist
-      cached = Object.assign(c || {}, {
-        ref: upstream,
-        counter: (c?.counter || 0) + 1,
-      })
-      cache.set(key, cached)
+      if (c) {
+        // another request did beat us to the punch
+        c.counter++
+        // (1) preserve cached reference; in-memory reference is always newer than from store
+        cached = c
+      } else {
+        // we're the first, so we must cache the reference
+        cached = { ref: upstream, counter: 0 }
+        cache.set(key, cached)
+      }
     }
 
     // TS already knows cached is always defined by this point, but does not guard cached.

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,13 +1,13 @@
 import { Context } from './context'
-import { MaybePromise } from './util'
+import { Any, MaybePromise } from './util'
 import { MiddlewareFn } from './middleware'
 import d from 'debug'
 const debug = d('telegraf:session')
 
 export interface SessionStore<T> {
   get: (name: string) => MaybePromise<T | undefined>
-  set: (name: string, value: T) => MaybePromise<void>
-  delete: (name: string) => MaybePromise<void>
+  set: (name: string, value: T) => MaybePromise<Any>
+  delete: (name: string) => MaybePromise<Any>
 }
 
 interface SessionOptions<S extends object, C extends Context = Context> {
@@ -26,13 +26,13 @@ export interface SessionContext<S extends object> extends Context {
  * The default `getSessionKey` is `${ctx.from.id}:${ctx.chat.id}`.
  * If either `ctx.from` or `ctx.chat` is `undefined`, default session key and thus `ctx.session` are also `undefined`.
  *
- * Session data is kept only in memory by default,
- * which means that all data will be lost when the process is terminated.
- * If you want to store data across restarts, or share it among workers,
- * you can [install persistent session middleware from npm](https://www.npmjs.com/search?q=telegraf-session),
- * or pass custom `storage`.
+ * > ⚠️ Session data is kept only in memory by default,  which means that all data will be lost when the process is terminated.
+ * >
+ * > If you want to store data across restarts, or share it among workers, you should use
+ * [@telegraf/session](https://www.npmjs.com/package/@telegraf/session), or pass custom `storage`.
  *
- * @example https://github.com/feathers-studio/telegraf-docs/blob/master/examples/session-bot.ts
+ * @see {@link https://github.com/feathers-studio/telegraf-docs/blob/b694bcc36b4f71fb1cd650a345c2009ab4d2a2a5/guide/session.md Telegraf Docs | Session}
+ * @see {@link https://github.com/feathers-studio/telegraf-docs/blob/master/examples/session-bot.ts Example}
  */
 export function session<S extends object, C extends Context = Context>(
   options?: SessionOptions<S, C>
@@ -142,7 +142,7 @@ async function defaultGetSessionKey(ctx: Context): Promise<string | undefined> {
   return `${fromId}:${chatId}`
 }
 
-/** @deprecated https://github.com/telegraf/telegraf/issues/1372#issuecomment-782668499 */
+/** @deprecated Use `Map` */
 export class MemorySessionStore<T> implements SessionStore<T> {
   private readonly store = new Map<string, { session: T; expires: number }>()
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,9 @@ import { FmtString } from './format'
 
 export const env = process.env
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type Any = {} | undefined | null
+
 export type Expand<T> = T extends object
   ? T extends infer O
     ? { [K in keyof O]: O[K] }

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -1,0 +1,114 @@
+const { Telegraf } = require('..')
+
+/** @type {import("../types").Message['from']} */
+const from = {
+  id: 1,
+  is_bot: false,
+  first_name: 'Enrico',
+  last_name: 'Fermi',
+}
+
+/** @type {import("../types").Message['chat']} */
+const chat = {
+  id: 1,
+  type: 'private',
+  first_name: 'Enrico',
+  last_name: 'Fermi',
+}
+
+let update_id = 1
+let message_id = 1
+
+/** @type { { message: { text:() => import("../types").Update.MessageUpdate<import("../types").Message.TextMessage> } } } */
+const Fixtures = {
+  message: {
+    text: () => ({
+      update_id: update_id++,
+      message: {
+        message_id: message_id++,
+        date: Date.now(),
+        from,
+        chat,
+        text: 'foo',
+      },
+    }),
+  },
+}
+
+const SyncStore = () => {
+  const map = new Map()
+
+  return {
+    map,
+    store: {
+      get: (name) => map.get(name),
+      set: (name, value) => void map.set(name, value),
+      delete: (name) => void map.delete(name),
+    },
+  }
+}
+
+const AsyncStore = () => {
+  const map = new Map()
+
+  return {
+    map,
+    store: {
+      async get(name) {
+        // API requests take time!
+        await randSleep(50)
+        return map.get(name)
+      },
+      async set(name, value) {
+        // API requests take time!
+        await randSleep(50)
+        map.set(name, value)
+      },
+      async delete(name) {
+        // API requests take time!
+        await randSleep(50)
+        map.delete(name)
+      },
+    },
+  }
+}
+
+const genericAsyncMiddleware = async (ctx, next) => {
+  await randSleep(200)
+  return await next()
+}
+
+/** @returns {any} */
+function createBot() {
+  const bot = new Telegraf('')
+  bot.botInfo = {
+    id: 42,
+    is_bot: true,
+    username: 'bot',
+    first_name: 'Bot',
+    can_join_groups: true,
+    can_read_all_group_messages: true,
+    supports_inline_queries: true,
+  }
+  return bot
+}
+
+/** @type {(n: number) => Promise<void>} */
+const sleep = (t) => new Promise((r) => setTimeout(r, t))
+
+/** @type {(n: number) => number} */
+const rand = (n) => Math.ceil(Math.random() * n)
+
+/** @type {(n: number) => Promise<void>} */
+const randSleep = (n) => sleep(rand(n))
+
+module.exports = {
+  SyncStore,
+  AsyncStore,
+  Fixtures,
+  rand,
+  sleep,
+  createBot,
+  randSleep,
+  genericAsyncMiddleware,
+}

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const { Telegraf } = require('..')
 
 /** @type {import("../types").Message['from']} */

--- a/test/session.js
+++ b/test/session.js
@@ -1,0 +1,124 @@
+// @ts-check
+
+const test = require('ava').default
+const { session } = require('..')
+
+const {
+  SyncStore,
+  AsyncStore,
+  Fixtures,
+  createBot,
+  randSleep,
+  genericAsyncMiddleware,
+} = require('./_helpers')
+
+/** @typedef {import('..').Context & { session: { count: number } }} MyCtx */
+
+/*
+
+This is testing essentially the following logic:
+
+Setup:
+* store is sync, but middlewares aren't
+* fire all updates simultaneously
+
+If racing were to occur, ctx.session would repeatedly get overwritten
+
+We test that it did not in fact get overwritten, and many updates were
+able to concurrently read and write to session asynchronously without racing
+
+*/
+test('must resist session racing (with sync store)', (t) =>
+  t.notThrowsAsync(
+    new Promise((resolve) => {
+      /** @type {import('..').Telegraf<MyCtx>} */
+      const bot = createBot()
+
+      const { store, map } = SyncStore()
+      bot.use(session({ store }))
+
+      // pretend there are other middlewares that slow down by a random amount
+      bot.use(genericAsyncMiddleware)
+
+      bot.on('message', async (ctx) => {
+        if (ctx.session === undefined) {
+          ctx.session = { count: 1 }
+        } else {
+          ctx.session.count++
+        }
+
+        // pretend we make an API call, etc
+        await randSleep(200)
+      })
+
+      // pretend there are other middlewares that slow down by a random amount
+      bot.use(genericAsyncMiddleware)
+
+      Promise.all(
+        Array
+          // create 100 text updates and fire them all at once
+          .from({ length: 100 }, Fixtures.message.text)
+          .map((fixture) => bot.handleUpdate(fixture))
+      ).then(() => {
+        const entries = [...map.entries()]
+        t.deepEqual(entries.length, 1)
+        const [key, value] = entries[0]
+        t.deepEqual(key, '1:1')
+        t.deepEqual(value, { count: 100 })
+        resolve(true)
+      })
+    })
+  ))
+
+/*
+
+This is testing essentially the following logic:
+
+Setup:
+* everything is async - store, and middlewares
+* fire all updates simultaneously
+
+If racing were to occur, ctx.session would repeatedly get overwritten
+
+We test that it did not in fact get overwritten, and many updates were
+able to concurrently read and write to session asynchronously without racing
+
+*/
+test('must resist session racing (with async store)', (t) =>
+  t.notThrowsAsync(
+    new Promise((resolve) => {
+      /** @type {import('..').Telegraf<MyCtx>} */
+      const bot = createBot()
+
+      const { store, map } = AsyncStore()
+      bot.use(session({ store }))
+
+      bot.on('message', async (ctx) => {
+        if (ctx.session === undefined) {
+          ctx.session = { count: 1 }
+        } else {
+          ctx.session.count++
+        }
+
+        // pretend we make an API call, etc
+        await randSleep(200)
+      })
+
+      // pretend there are other middlewares that slow down by a random amount
+      bot.use(genericAsyncMiddleware)
+
+      Promise.all(
+        Array
+          // create 100 text updates and fire them all at once
+          .from({ length: 100 }, Fixtures.message.text)
+          .map((fixture) => bot.handleUpdate(fixture))
+      ).then(() => {
+        const entries = [...map.entries()]
+        t.deepEqual(entries.length, 1)
+        const [key, value] = entries[0]
+        t.deepEqual(key, '1:1')
+        t.deepEqual(value, { count: 100 })
+        resolve(true)
+      })
+    })
+  ))


### PR DESCRIPTION
Fixes #1372, fixes #1695, fixes #1799
Supersedes #1436

This is a very involved, but well-commented solution. Short explanation follows.

Edit: This PR now also introduces `defaultSession` as an optional parameter to `session({})`. Unit tests have been updated.

### Current state:

1. Telegraf receives two messages from the same Telegram chat+user
2. Telegraf reads session from store in both updates
3. Both updates run through the middleware system
4. When they're done, they both update store, BUT one doesn't know that the other message also performed an update, so it overwrites session, losing data

### Solution:

1. Receive two messages concurrently
2. First update to fetch the session caches it in memory with a reference and counter
3. Everyone else checks the cache, and see that it's already in memory, so they just increment the counter and reuse the reference
4. When every update is done processing, counter is decremented
5. If counter reaches zero, the reference object is cleared from memory cache

### Problems:

1. ⚠️VERY IMPORTANT!
	~If an update is terminated halfway (because it threw an error), any changes it already made are not rolled back in the memory cache. If other concurrent requests are using the reference, they will see the updated object, and if they complete processing successfully, the updated session will persist! We could make this behaviour more predictable by also persisting session in the error catch branch.~
	This behaviour has been changed so session is always written back, regardless of whether middleware chain completes or errors. This means assigning to session is always almost as good as having written to store.
3. `getSessionKey` is async in v4, so it still allows some racing, but provided solution automatically corrects for this by ignoring duplicate store fetches if a reference is already cached when they return. In v5, `getSessionKey` should probably be made synchronous—counter-arguments welcome.
4. This solution does not protect the user from introducing race-conditions of their own. We cannot prevent them from doing that, but we can document this as a possible footgun.
5. Obviously any solution relying on synchronous in-memory cache does not scale horizontally. This solution will protect single-process session users only.
	* In the future (v5?), this may be expanded to use Worker threads / Web Workers where they synchronise using `SharedArrayBuffer` and `Atomics`. Will explore this if there is demand for such a thing.
	* Multi-process support (especially useful for FaaS and edge runtimes and probably more important than workers) could be implemented using db mutexes. But this also enforces sequentialisation across all processes for a given session key. Concurrency is easy; safe concurrency is hard. Maybe there are other solutions; we're not exploring them for now, but maybe in the future.
	* Meanwhile, we can recommend simply using a custom `getSessionKey :: ctx -> ctx.chat.id` for webhooks. Telegram ensures that webhook updates are serial for a given chatId already!
6. ~`session` has to be an object for references to be shared. It cannot be a primitive value. This is already true for Telegraf, because Scenes and Wizards cannot work otherwise.~ This is not true; since this PR, session can be a primitive, but we're leaving the type-level constraint in place until someone asks for it.

If there are concerns about this solution subtly changing the behaviour of existing deprecated `session`, particularly in multi-process situations, I'm open to discussion about splitting this into an external module at `@telegraf/session` which users can opt-in to, with the naive implementation as the default.

However, I don't like the idea of permanently moving session out of telegraf core as previously discussed in #1436, because other core (Scenes and Wizards) and thirdparty modules inherently rely on sessions to exist.

### Testing

The original reproduction code posted in #1372 works as expected with the proposed version of session. Try it yourself by installing this branch:

```shell
npm i "telegraf/telegraf#feat-better-session"
```

```TS
"use strict"

const { Telegraf, session } = require("telegraf")
const createDebug = require("debug")

const bot = new Telegraf(process.env.BOT_TOKEN)
const debug = createDebug('test')

bot.use(session())
bot.on('message', async ctx => {
  if (ctx.session === undefined) {
    const { update_id } = ctx.update
    ctx.session = { update_id }
    debug('Defaulting session to', ctx.session)
  } else {
    debug('Session already set to', ctx.session)
  }
})

createDebug.enable('telegraf:client test')
bot.launch()
```

Further, unit tests have been added with synchronous and asynchronous session stores. They appear rock-solid, but if anyone wants to produce a breaking test, I'd be happy to fix the implementation to conform.