### PR TITLE
Fix: typo of `4.9.1` Release note.

### DIFF
--- a/release-notes/4.9.1.md
+++ b/release-notes/4.9.1.md
@@ -1,4 +1,4 @@
 # v4.9.1
 
 * Updated typegram to v3.11.0.
-* (internal) Simplifed cli, dropped two dependencies.
+* (internal) Simplified cli, dropped two dependencies.


### PR DESCRIPTION
## Description

Hello, everyone in the community! :)
I found typo of `4.9.1` Release note.
And I fixed it!

## ETC

This is part of Hacktoberfest's participation, very minor PR.
But hopefully it will help the open-source ecosystem.