### PR TITLE
API 6.3

### DIFF
--- a/release-notes/4.11.0.md
+++ b/release-notes/4.11.0.md
@@ -1,0 +1,85 @@
+# 4.11.0 - API 6.3 & filters
+
+## 🔺 Bot API 6.3 support
+
+* Updated to Typegram 4.1.0 and added the following new methods to `Telegram` class:
+  * `createForumTopic`
+  * `editForumTopic`
+  * `closeForumTopic`
+  * `reopenForumTopic`
+  * `deleteForumTopic`
+  * `unpinAllForumTopicMessages`
+  * `getForumTopicIconStickers`
+* Added new method shorthands to `Context`; add `message_thread_id` implicitly to all context methods that take it.
+
+## ✨ Filters! ✨
+
+We've added a new powerful feature called filters! Here's how to use them.
+
+```TS
+// import our filters
+import { message, editedMessage, channelPost, editedChannelPost, callbackQuery } from "telegraf/filters";
+// you can also use require, like this:
+// const { message, editedMessage, channelPost, editedChannelPost, callbackQuery } = require("telegraf/filters");
+
+const bot = new Telegraf(token);
+
+bot.on(message("text"), ctx => {
+  // this is a text message update
+  // ctx.message.text
+});
+
+bot.on(channelPost("video"), ctx => {
+  // this is a video channel post update
+  // ctx.channelPost.video
+});
+
+bot.on(callbackQuery("game_short_name"), ctx => {
+  // this is a video channel post update
+  // ctx.callbackQuery.game_short_name
+});
+```
+
+This unlocks the ability to filter for very specific update types previously not possible! This is only an initial release, and filters will become even more powerful in future updates.
+
+All filters are also usable from a new method, `ctx.has`. This is very useful if you want to filter within a handler. For example:
+
+```TS
+// handles all updates
+bot.use(ctx => {
+  if (ctx.has(message("text"))) {
+    // handles only text messages
+    // ctx.message.text;
+  } else {
+    // handles all other messages
+  }
+});
+```
+
+Like `bot.on`, `ctx.has` also supports an array of update types and filters, even mixed:
+
+```TS
+// match a message update or a callbackQuery with data present
+bot.on(["message", callbackQuery("data")], handler);
+
+if (ctx.has(["message", callbackQuery("data")])) {
+  // ctx.update is a message update or a callbackQuery with data present
+};
+```
+
+## ⚠️ Deprecating `bot.on` with message types!
+
+As of this release, filtering by _**message type**_ using `bot.on()` (for example: "text", "photo", etc.) is deprecated. Don't panic, though! Your existing bots will continue to work, but whenever you can, you must update your message type filters to use the above filters before v5. This is fairly easy to do, like this:
+
+```diff
+- bot.on("text", handler);
++ bot.on(message("text"), handler);
+```
+
+The deprecated message type behaviour will be removed in v5.
+
+You might be happy, or fairly upset about this development. But it was important we made this decision. For a long time, Telegraf has supported filtering by both update type and message type.
+
+This meant you could use `bot.on("message")`, or `bot.on("text")` (text here is a message type, and not an update type, so this was really making sure that `update.message.text` existed). However, when polls were introduced, this caused a conflict. `bot.on("poll")` would match both `update.poll` (update about stopped polls sent by the bot) and `update.message.poll` (a message that is a native poll). At type-level, both objects will show as available, which was wrong.
+
+Besides, this type of filters really limited how far we could go with Telegraf. That's why we introduced filters, which are way more powerful and flexible!

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,6 +4,7 @@ import { Deunionize, PropOr, UnionKeys } from './deunionize'
 import ApiClient from './core/network/client'
 import { deprecate, Guard, Guarded, MaybeArray } from './util'
 import Telegram from './telegram'
+import { FmtString } from './format'
 
 type Tail<T> = T extends [unknown, ...infer U] ? U : never
 
@@ -392,9 +393,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendmessage
    */
-  sendMessage(this: Context, ...args: Shorthand<'sendMessage'>) {
+  sendMessage(
+    this: Context,
+    text: string | FmtString,
+    extra?: Shorthand<'sendMessage'>[1]
+  ) {
     this.assert(this.chat, 'sendMessage')
-    return this.telegram.sendMessage(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendMessage(this.chat.id, text, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -629,9 +638,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendphoto
    */
-  sendPhoto(this: Context, ...args: Shorthand<'sendPhoto'>) {
+  sendPhoto(
+    this: Context,
+    photo: string | tg.InputFile,
+    extra?: Shorthand<'sendPhoto'>[1]
+  ) {
     this.assert(this.chat, 'sendPhoto')
-    return this.telegram.sendPhoto(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendPhoto(this.chat.id, photo, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -650,9 +667,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendmediagroup
    */
-  sendMediaGroup(this: Context, ...args: Shorthand<'sendMediaGroup'>) {
+  sendMediaGroup(
+    this: Context,
+    media: Shorthand<'sendMediaGroup'>[0],
+    extra?: Shorthand<'sendMediaGroup'>[1]
+  ) {
     this.assert(this.chat, 'sendMediaGroup')
-    return this.telegram.sendMediaGroup(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendMediaGroup(this.chat.id, media, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -671,9 +696,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendaudio
    */
-  sendAudio(this: Context, ...args: Shorthand<'sendAudio'>) {
+  sendAudio(
+    this: Context,
+    audio: string | tg.InputFile,
+    extra?: Shorthand<'sendAudio'>[1]
+  ) {
     this.assert(this.chat, 'sendAudio')
-    return this.telegram.sendAudio(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendAudio(this.chat.id, audio, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -692,9 +725,13 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#senddice
    */
-  sendDice(this: Context, ...args: Shorthand<'sendDice'>) {
+  sendDice(this: Context, extra?: Shorthand<'sendDice'>[0]) {
     this.assert(this.chat, 'sendDice')
-    return this.telegram.sendDice(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendDice(this.chat.id, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -713,9 +750,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#senddocument
    */
-  sendDocument(this: Context, ...args: Shorthand<'sendDocument'>) {
+  sendDocument(
+    this: Context,
+    document: string | tg.InputFile,
+    extra?: Shorthand<'sendDocument'>[1]
+  ) {
     this.assert(this.chat, 'sendDocument')
-    return this.telegram.sendDocument(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendDocument(this.chat.id, document, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -734,9 +779,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendsticker
    */
-  sendSticker(this: Context, ...args: Shorthand<'sendSticker'>) {
+  sendSticker(
+    this: Context,
+    sticker: string | tg.InputFile,
+    extra?: Shorthand<'sendSticker'>[1]
+  ) {
     this.assert(this.chat, 'sendSticker')
-    return this.telegram.sendSticker(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendSticker(this.chat.id, sticker, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -755,9 +808,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendvideo
    */
-  sendVideo(this: Context, ...args: Shorthand<'sendVideo'>) {
+  sendVideo(
+    this: Context,
+    video: string | tg.InputFile,
+    extra?: Shorthand<'sendVideo'>[1]
+  ) {
     this.assert(this.chat, 'sendVideo')
-    return this.telegram.sendVideo(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendVideo(this.chat.id, video, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -776,9 +837,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendanimation
    */
-  sendAnimation(this: Context, ...args: Shorthand<'sendAnimation'>) {
+  sendAnimation(
+    this: Context,
+    animation: string | tg.InputFile,
+    extra?: Shorthand<'sendAnimation'>[1]
+  ) {
     this.assert(this.chat, 'sendAnimation')
-    return this.telegram.sendAnimation(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendAnimation(this.chat.id, animation, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -797,9 +866,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendvideonote
    */
-  sendVideoNote(this: Context, ...args: Shorthand<'sendVideoNote'>) {
+  sendVideoNote(
+    this: Context,
+    videoNote: string | tg.InputFileVideoNote,
+    extra?: Shorthand<'sendVideoNote'>[1]
+  ) {
     this.assert(this.chat, 'sendVideoNote')
-    return this.telegram.sendVideoNote(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendVideoNote(this.chat.id, videoNote, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -818,9 +895,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendinvoice
    */
-  sendInvoice(this: Context, ...args: Shorthand<'sendInvoice'>) {
+  sendInvoice(
+    this: Context,
+    invoice: Shorthand<'sendInvoice'>[0],
+    extra?: Shorthand<'sendInvoice'>[1]
+  ) {
     this.assert(this.chat, 'sendInvoice')
-    return this.telegram.sendInvoice(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendInvoice(this.chat.id, invoice, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -839,9 +924,13 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendgame
    */
-  sendGame(this: Context, ...args: Shorthand<'sendGame'>) {
+  sendGame(this: Context, game: string, extra?: Shorthand<'sendGame'>[1]) {
     this.assert(this.chat, 'sendGame')
-    return this.telegram.sendGame(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendGame(this.chat.id, game, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -860,9 +949,17 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendvoice
    */
-  sendVoice(this: Context, ...args: Shorthand<'sendVoice'>) {
+  sendVoice(
+    this: Context,
+    voice: string | tg.InputFile,
+    extra?: Shorthand<'sendVoice'>[1]
+  ) {
     this.assert(this.chat, 'sendVoice')
-    return this.telegram.sendVoice(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendVoice(this.chat.id, voice, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -881,9 +978,18 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendpoll
    */
-  sendPoll(this: Context, ...args: Shorthand<'sendPoll'>) {
+  sendPoll(
+    this: Context,
+    poll: string,
+    options: readonly string[],
+    extra?: Shorthand<'sendPoll'>[2]
+  ) {
     this.assert(this.chat, 'sendPoll')
-    return this.telegram.sendPoll(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendPoll(this.chat.id, poll, options, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -900,15 +1006,24 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#sendquiz
+   * @see https://core.telegram.org/bots/api#sendpoll
    */
-  sendQuiz(this: Context, ...args: Shorthand<'sendQuiz'>) {
+  sendQuiz(
+    this: Context,
+    quiz: string,
+    options: readonly string[],
+    extra?: Shorthand<'sendQuiz'>[2]
+  ) {
     this.assert(this.chat, 'sendQuiz')
-    return this.telegram.sendQuiz(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendQuiz(this.chat.id, quiz, options, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
-   * @see https://core.telegram.org/bots/api#sendquiz
+   * @see https://core.telegram.org/bots/api#sendpoll
    */
   replyWithQuiz(this: Context, ...args: Shorthand<'sendQuiz'>) {
     deprecate(
@@ -948,9 +1063,18 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendlocation
    */
-  sendLocation(this: Context, ...args: Shorthand<'sendLocation'>) {
+  sendLocation(
+    this: Context,
+    latitude: number,
+    longitude: number,
+    extra?: Shorthand<'sendLocation'>[2]
+  ) {
     this.assert(this.chat, 'sendLocation')
-    return this.telegram.sendLocation(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendLocation(this.chat.id, latitude, longitude, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -969,9 +1093,24 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendvenue
    */
-  sendVenue(this: Context, ...args: Shorthand<'sendVenue'>) {
+  sendVenue(
+    this: Context,
+    latitude: number,
+    longitude: number,
+    title: string,
+    address: string,
+    extra?: Shorthand<'sendVenue'>[4]
+  ) {
     this.assert(this.chat, 'sendVenue')
-    return this.telegram.sendVenue(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendVenue(
+      this.chat.id,
+      latitude,
+      longitude,
+      title,
+      address,
+      { message_thread_id, ...extra }
+    )
   }
 
   /**
@@ -990,9 +1129,18 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendcontact
    */
-  sendContact(this: Context, ...args: Shorthand<'sendContact'>) {
+  sendContact(
+    this: Context,
+    phoneNumber: string,
+    firstName: string,
+    extra?: Shorthand<'sendContact'>[2]
+  ) {
     this.assert(this.chat, 'sendContact')
-    return this.telegram.sendContact(this.chat.id, ...args)
+    const { message_thread_id } = this.message || {}
+    return this.telegram.sendContact(this.chat.id, phoneNumber, firstName, {
+      message_thread_id,
+      ...extra,
+    })
   }
 
   /**
@@ -1247,9 +1395,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   forwardMessage(
     this: Context,
     chatId: string | number,
-    extra?: {
-      disable_notification?: boolean
-    }
+    extra?: Shorthand<'forwardMessage'>[2]
   ) {
     const message = getMessageFromAnySource(this)
     this.assert(message, 'forwardMessage')

--- a/src/context.ts
+++ b/src/context.ts
@@ -196,7 +196,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @internal
    */
-  assert<T extends string | object>(
+  assert<T extends string | number | object>(
     value: T | undefined,
     method: string
   ): asserts value is T {
@@ -1030,6 +1030,102 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   deleteChatStickerSet(this: Context) {
     this.assert(this.chat, 'deleteChatStickerSet')
     return this.telegram.deleteChatStickerSet(this.chat.id)
+  }
+
+  /**
+   * Use this method to create a topic in a forum supergroup chat. The bot must be an administrator in the chat for this
+   * to work and must have the can_manage_topics administrator rights. Returns information about the created topic as a
+   * ForumTopic object.
+   *
+   * @see https://core.telegram.org/bots/api#createforumtopic
+   */
+  createForumTopic(this: Context, ...args: Shorthand<'createForumTopic'>) {
+    this.assert(this.chat, 'createForumTopic')
+    return this.telegram.createForumTopic(this.chat.id, ...args)
+  }
+
+  /**
+   * Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an administrator in
+   * the chat for this to work and must have can_manage_topics administrator rights, unless it is the creator of the
+   * topic. Returns True on success.
+   *
+   * @see https://core.telegram.org/bots/api#editforumtopic
+   */
+  editForumTopic(this: Context, extra: tt.ExtraEditForumTopic) {
+    this.assert(this.chat, 'editForumTopic')
+    this.assert(this.message?.message_thread_id, 'editForumTopic')
+    return this.telegram.editForumTopic(
+      this.chat.id,
+      this.message.message_thread_id,
+      extra
+    )
+  }
+
+  /**
+   * Use this method to close an open topic in a forum supergroup chat. The bot must be an administrator in the chat
+   * for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+   * Returns True on success.
+   *
+   * @see https://core.telegram.org/bots/api#closeforumtopic
+   */
+  closeForumTopic(this: Context) {
+    this.assert(this.chat, 'closeForumTopic')
+    this.assert(this.message?.message_thread_id, 'closeForumTopic')
+
+    return this.telegram.closeForumTopic(
+      this.chat.id,
+      this.message.message_thread_id
+    )
+  }
+
+  /**
+   * Use this method to reopen a closed topic in a forum supergroup chat. The bot must be an administrator in the chat
+   * for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+   * Returns True on success.
+   *
+   * @see https://core.telegram.org/bots/api#reopenforumtopic
+   */
+  reopenForumTopic(this: Context) {
+    this.assert(this.chat, 'reopenForumTopic')
+    this.assert(this.message?.message_thread_id, 'reopenForumTopic')
+
+    return this.telegram.reopenForumTopic(
+      this.chat.id,
+      this.message.message_thread_id
+    )
+  }
+
+  /**
+   * Use this method to delete a forum topic along with all its messages in a forum supergroup chat. The bot must be an
+   * administrator in the chat for this to work and must have the can_delete_messages administrator rights.
+   * Returns True on success.
+   *
+   * @see https://core.telegram.org/bots/api#deleteforumtopic
+   */
+  deleteForumTopic(this: Context) {
+    this.assert(this.chat, 'deleteForumTopic')
+    this.assert(this.message?.message_thread_id, 'deleteForumTopic')
+
+    return this.telegram.deleteForumTopic(
+      this.chat.id,
+      this.message.message_thread_id
+    )
+  }
+
+  /**
+   * Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the chat
+   * for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success.
+   *
+   * @see https://core.telegram.org/bots/api#unpinallforumtopicmessages
+   */
+  unpinAllForumTopicMessages(this: Context) {
+    this.assert(this.chat, 'unpinAllForumTopicMessages')
+    this.assert(this.message?.message_thread_id, 'unpinAllForumTopicMessages')
+
+    return this.telegram.unpinAllForumTopicMessages(
+      this.chat.id,
+      this.message.message_thread_id
+    )
   }
 
   /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -396,7 +396,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendMessage(
     this: Context,
     text: string | FmtString,
-    extra?: Shorthand<'sendMessage'>[1]
+    extra?: tt.ExtraReplyMessage
   ) {
     this.assert(this.chat, 'sendMessage')
     const { message_thread_id } = this.message || {}
@@ -641,7 +641,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendPhoto(
     this: Context,
     photo: string | tg.InputFile,
-    extra?: Shorthand<'sendPhoto'>[1]
+    extra?: tt.ExtraPhoto
   ) {
     this.assert(this.chat, 'sendPhoto')
     const { message_thread_id } = this.message || {}
@@ -669,8 +669,8 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
    */
   sendMediaGroup(
     this: Context,
-    media: Shorthand<'sendMediaGroup'>[0],
-    extra?: Shorthand<'sendMediaGroup'>[1]
+    media: tt.MediaGroup,
+    extra?: tt.ExtraMediaGroup
   ) {
     this.assert(this.chat, 'sendMediaGroup')
     const { message_thread_id } = this.message || {}
@@ -699,7 +699,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendAudio(
     this: Context,
     audio: string | tg.InputFile,
-    extra?: Shorthand<'sendAudio'>[1]
+    extra?: tt.ExtraAudio
   ) {
     this.assert(this.chat, 'sendAudio')
     const { message_thread_id } = this.message || {}
@@ -725,7 +725,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#senddice
    */
-  sendDice(this: Context, extra?: Shorthand<'sendDice'>[0]) {
+  sendDice(this: Context, extra?: tt.ExtraDice) {
     this.assert(this.chat, 'sendDice')
     const { message_thread_id } = this.message || {}
     return this.telegram.sendDice(this.chat.id, {
@@ -753,7 +753,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendDocument(
     this: Context,
     document: string | tg.InputFile,
-    extra?: Shorthand<'sendDocument'>[1]
+    extra?: tt.ExtraDocument
   ) {
     this.assert(this.chat, 'sendDocument')
     const { message_thread_id } = this.message || {}
@@ -782,7 +782,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendSticker(
     this: Context,
     sticker: string | tg.InputFile,
-    extra?: Shorthand<'sendSticker'>[1]
+    extra?: tt.ExtraSticker
   ) {
     this.assert(this.chat, 'sendSticker')
     const { message_thread_id } = this.message || {}
@@ -811,7 +811,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendVideo(
     this: Context,
     video: string | tg.InputFile,
-    extra?: Shorthand<'sendVideo'>[1]
+    extra?: tt.ExtraVideo
   ) {
     this.assert(this.chat, 'sendVideo')
     const { message_thread_id } = this.message || {}
@@ -840,7 +840,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendAnimation(
     this: Context,
     animation: string | tg.InputFile,
-    extra?: Shorthand<'sendAnimation'>[1]
+    extra?: tt.ExtraAnimation
   ) {
     this.assert(this.chat, 'sendAnimation')
     const { message_thread_id } = this.message || {}
@@ -869,7 +869,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendVideoNote(
     this: Context,
     videoNote: string | tg.InputFileVideoNote,
-    extra?: Shorthand<'sendVideoNote'>[1]
+    extra?: tt.ExtraVideoNote
   ) {
     this.assert(this.chat, 'sendVideoNote')
     const { message_thread_id } = this.message || {}
@@ -897,8 +897,8 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
    */
   sendInvoice(
     this: Context,
-    invoice: Shorthand<'sendInvoice'>[0],
-    extra?: Shorthand<'sendInvoice'>[1]
+    invoice: tt.NewInvoiceParameters,
+    extra?: tt.ExtraInvoice
   ) {
     this.assert(this.chat, 'sendInvoice')
     const { message_thread_id } = this.message || {}
@@ -924,7 +924,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#sendgame
    */
-  sendGame(this: Context, game: string, extra?: Shorthand<'sendGame'>[1]) {
+  sendGame(this: Context, game: string, extra?: tt.ExtraGame) {
     this.assert(this.chat, 'sendGame')
     const { message_thread_id } = this.message || {}
     return this.telegram.sendGame(this.chat.id, game, {
@@ -952,7 +952,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   sendVoice(
     this: Context,
     voice: string | tg.InputFile,
-    extra?: Shorthand<'sendVoice'>[1]
+    extra?: tt.ExtraVoice
   ) {
     this.assert(this.chat, 'sendVoice')
     const { message_thread_id } = this.message || {}
@@ -982,7 +982,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     this: Context,
     poll: string,
     options: readonly string[],
-    extra?: Shorthand<'sendPoll'>[2]
+    extra?: tt.ExtraPoll
   ) {
     this.assert(this.chat, 'sendPoll')
     const { message_thread_id } = this.message || {}
@@ -1012,7 +1012,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     this: Context,
     quiz: string,
     options: readonly string[],
-    extra?: Shorthand<'sendQuiz'>[2]
+    extra?: tt.ExtraPoll
   ) {
     this.assert(this.chat, 'sendQuiz')
     const { message_thread_id } = this.message || {}
@@ -1067,7 +1067,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     this: Context,
     latitude: number,
     longitude: number,
-    extra?: Shorthand<'sendLocation'>[2]
+    extra?: tt.ExtraLocation
   ) {
     this.assert(this.chat, 'sendLocation')
     const { message_thread_id } = this.message || {}
@@ -1099,7 +1099,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     longitude: number,
     title: string,
     address: string,
-    extra?: Shorthand<'sendVenue'>[4]
+    extra?: tt.ExtraVenue
   ) {
     this.assert(this.chat, 'sendVenue')
     const { message_thread_id } = this.message || {}
@@ -1133,7 +1133,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     this: Context,
     phoneNumber: string,
     firstName: string,
-    extra?: Shorthand<'sendContact'>[2]
+    extra?: tt.ExtraContact
   ) {
     this.assert(this.chat, 'sendContact')
     const { message_thread_id } = this.message || {}

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -2,6 +2,12 @@
 
 import { Expand } from './util'
 import { Message, Opts, Telegram, Update } from './core/types/typegram'
+import {
+  InputMediaAudio,
+  InputMediaDocument,
+  InputMediaPhoto,
+  InputMediaVideo,
+} from 'typegram'
 import { UnionKeys } from './deunionize'
 import { FmtString } from './format'
 
@@ -122,6 +128,11 @@ export type ExtraEditForumTopic = MakeExtra<
   'editForumTopic',
   'message_thread_id'
 >
+
+export type MediaGroup =
+  | readonly (InputMediaPhoto | InputMediaVideo)[]
+  | readonly InputMediaAudio[]
+  | readonly InputMediaDocument[]
 
 // types used for inference of ctx object
 

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -83,6 +83,7 @@ export type NewInvoiceParameters = MakeExtra<
   | 'reply_to_message_id'
   | 'allow_sending_without_reply'
   | 'reply_markup'
+  | 'message_thread_id'
 >
 export type ExtraInvoice = MakeExtra<'sendInvoice', keyof NewInvoiceParameters>
 export type ExtraBanChatMember = MakeExtra<
@@ -96,6 +97,10 @@ export type ExtraPhoto = MakeExtra<'sendPhoto', 'photo'>
 export type ExtraPoll = MakeExtra<'sendPoll', 'question' | 'options' | 'type'>
 export type ExtraPromoteChatMember = MakeExtra<'promoteChatMember', 'user_id'>
 export type ExtraReplyMessage = MakeExtra<'sendMessage', 'text'>
+export type ExtraForwardMessage = MakeExtra<
+  'forwardMessage',
+  'from_chat_id' | 'message_id'
+>
 export type ExtraRestrictChatMember = MakeExtra<'restrictChatMember', 'user_id'>
 export type ExtraSetMyCommands = MakeExtra<'setMyCommands', 'commands'>
 export type ExtraSetWebhook = MakeExtra<'setWebhook', 'url'>
@@ -111,6 +116,11 @@ export type ExtraVoice = MakeExtra<'sendVoice', 'voice'>
 export type ExtraBanChatSenderChat = MakeExtra<
   'banChatSenderChat',
   'sender_chat_id'
+>
+export type ExtraCreateForumTopic = MakeExtra<'createForumTopic', 'name'>
+export type ExtraEditForumTopic = MakeExtra<
+  'editForumTopic',
+  'message_thread_id'
 >
 
 // types used for inference of ctx object

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -393,10 +393,7 @@ export class Telegram extends ApiClient {
    */
   sendMediaGroup(
     chatId: number | string,
-    media:
-      | ReadonlyArray<tg.InputMediaPhoto | tg.InputMediaVideo>
-      | readonly tg.InputMediaAudio[]
-      | readonly tg.InputMediaDocument[],
+    media: tt.MediaGroup,
     extra?: tt.ExtraMediaGroup
   ) {
     return this.callApi('sendMediaGroup', { chat_id: chatId, media, ...extra })

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -148,7 +148,7 @@ export class Telegram extends ApiClient {
     chatId: number | string,
     fromChatId: number | string,
     messageId: number,
-    extra?: { disable_notification?: boolean }
+    extra?: tt.ExtraForwardMessage
   ) {
     return this.callApi('forwardMessage', {
       chat_id: chatId,
@@ -941,6 +941,130 @@ export class Telegram extends ApiClient {
 
   deleteChatStickerSet(chatId: number | string) {
     return this.callApi('deleteChatStickerSet', { chat_id: chatId })
+  }
+
+  /**
+   * Use this method to get custom emoji stickers, which can be used as a forum topic icon by any user.
+   * Requires no parameters. Returns an Array of Sticker objects.
+   *
+   * @see https://core.telegram.org/bots/api#getforumtopiciconstickers
+   */
+  getForumTopicIconStickers() {
+    return this.callApi('getForumTopicIconStickers', {})
+  }
+
+  /**
+   * Use this method to create a topic in a forum supergroup chat. The bot must be an administrator in the chat for this
+   * to work and must have the can_manage_topics administrator rights. Returns information about the created topic as a
+   * ForumTopic object.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param name Topic name, 1-128 characters
+   *
+   * @see https://core.telegram.org/bots/api#createforumtopic
+   */
+  createForumTopic(
+    chat_id: number | string,
+    name: string,
+    extra?: tt.ExtraCreateForumTopic
+  ) {
+    return this.callApi('createForumTopic', {
+      chat_id,
+      name,
+      ...extra,
+    })
+  }
+
+  /**
+   * Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an administrator in
+   * the chat for this to work and must have can_manage_topics administrator rights, unless it is the creator of the
+   * topic. Returns True on success.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param message_thread_id Unique identifier for the target message thread of the forum topic
+   *
+   * @see https://core.telegram.org/bots/api#editforumtopic
+   */
+  editForumTopic(
+    chat_id: number | string,
+    message_thread_id: number,
+    extra: tt.ExtraEditForumTopic
+  ) {
+    return this.callApi('editForumTopic', {
+      chat_id,
+      message_thread_id,
+      ...extra,
+    })
+  }
+
+  /**
+   * Use this method to close an open topic in a forum supergroup chat. The bot must be an administrator in the chat
+   * for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+   * Returns True on success.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param message_thread_id Unique identifier for the target message thread of the forum topic
+   *
+   * @see https://core.telegram.org/bots/api#closeforumtopic
+   */
+  closeForumTopic(chat_id: number | string, message_thread_id: number) {
+    return this.callApi('closeForumTopic', {
+      chat_id,
+      message_thread_id,
+    })
+  }
+
+  /**
+   * Use this method to reopen a closed topic in a forum supergroup chat. The bot must be an administrator in the chat
+   * for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic.
+   * Returns True on success.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param message_thread_id Unique identifier for the target message thread of the forum topic
+   *
+   * @see https://core.telegram.org/bots/api#reopenforumtopic
+   */
+  reopenForumTopic(chat_id: number | string, message_thread_id: number) {
+    return this.callApi('reopenForumTopic', {
+      chat_id,
+      message_thread_id,
+    })
+  }
+
+  /**
+   * Use this method to delete a forum topic along with all its messages in a forum supergroup chat. The bot must be an
+   * administrator in the chat for this to work and must have the can_delete_messages administrator rights.
+   * Returns True on success.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param message_thread_id Unique identifier for the target message thread of the forum topic
+   *
+   * @see https://core.telegram.org/bots/api#deleteforumtopic
+   */
+  deleteForumTopic(chat_id: number | string, message_thread_id: number) {
+    return this.callApi('deleteForumTopic', {
+      chat_id,
+      message_thread_id,
+    })
+  }
+
+  /**
+   * Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the chat
+   * for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success.
+   *
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param message_thread_id Unique identifier for the target message thread of the forum topic
+   *
+   * @see https://core.telegram.org/bots/api#unpinallforumtopicmessages
+   */
+  unpinAllForumTopicMessages(
+    chat_id: number | string,
+    message_thread_id: number
+  ) {
+    return this.callApi('unpinAllForumTopicMessages', {
+      chat_id,
+      message_thread_id,
+    })
   }
 
   getStickerSet(name: string) {


### PR DESCRIPTION
* Update to Typegram 4.1.0.
* Add the new methods [createForumTopic](https://core.telegram.org/bots/api#createforumtopic), [editForumTopic](https://core.telegram.org/bots/api#editforumtopic), [closeForumTopic](https://core.telegram.org/bots/api#closeforumtopic), [reopenForumTopic](https://core.telegram.org/bots/api#reopenforumtopic), [deleteForumTopic](https://core.telegram.org/bots/api#deleteforumtopic), [unpinAllForumTopicMessages](https://core.telegram.org/bots/api#unpinallforumtopicmessages), and [getForumTopicIconStickers](https://core.telegram.org/bots/api#getforumtopiciconstickers) to Telegram.
* Add all the same method shorthands to Context except [getForumTopicIconStickers](https://core.telegram.org/bots/api#getforumtopiciconstickers).
* Implicitly add `message_thread_id` to the Context methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [sendGame](https://core.telegram.org/bots/api#sendgame), [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup).
* `message_thread_id` is not implicitly added to [copyMessage](https://core.telegram.org/bots/api#copymessage) and [forwardMessage](https://core.telegram.org/bots/api#forwardmessage).
* Fix types for [forwardMessage](https://core.telegram.org/bots/api#forwardmessage), so it accepts `protect_content` and `message_thread_id` now.

Canary release for testing: `telegraf@4.11.0-canary.1`