### PR TITLE
API 6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p>Modern Telegram Bot API framework for Node.js</p>
 
 <a href="https://core.telegram.org/bots/api">
-	<img src="https://img.shields.io/badge/Bot%20API-v6.3-f36caf.svg?style=flat-square" alt="Bot API Version" />
+	<img src="https://img.shields.io/badge/Bot%20API-v6.5-f36caf.svg?style=flat-square" alt="Bot API Version" />
 </a>
 <a href="https://packagephobia.com/result?p=telegraf,node-telegram-bot-api">
 	<img src="https://flat.badgen.net/packagephobia/install/telegraf" alt="install size" />
@@ -37,7 +37,7 @@ Telegraf is a library that makes it simple for you to develop your own Telegram 
 
 ### Features
 
-- Full [Telegram Bot API 6.3](https://core.telegram.org/bots/api) support
+- Full [Telegram Bot API 6.5](https://core.telegram.org/bots/api) support
 - [Excellent TypeScript typings](https://github.com/telegraf/telegraf/releases/tag/v4.0.0)
 - [Lightweight](https://packagephobia.com/result?p=telegraf,node-telegram-bot-api)
 - [AWS **λ**](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html)
@@ -158,7 +158,7 @@ Here is a list of
 
 ```js
 import { Telegraf } from 'telegraf';
-const { message } = require('telegraf/filters');
+import { message } from 'telegraf/filters';
 
 const bot = new Telegraf(process.env.BOT_TOKEN);
 
@@ -208,7 +208,7 @@ process.once('SIGTERM', () => bot.stop('SIGTERM'));
 
 ```TS
 import { Telegraf } from "telegraf";
-const { message } = require('telegraf/filters');
+import { message } from 'telegraf/filters';
 
 const bot = new Telegraf(token);
 
@@ -316,7 +316,7 @@ As in Koa and some other middleware-based libraries,
 
 ```TS
 import { Telegraf } from 'telegraf';
-const { message } = require('telegraf/filters');
+import { message } from 'telegraf/filters';
 
 const bot = new Telegraf(process.env.BOT_TOKEN);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telegraf",
-  "version": "4.11.2",
+  "version": "4.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "telegraf",
-      "version": "4.11.2",
+      "version": "4.12.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -16,7 +16,7 @@
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
         "sandwich-stream": "^2.0.2",
-        "typegram": "^4.2.0"
+        "typegram": "^4.3.0"
       },
       "bin": {
         "telegraf": "lib/cli.mjs"
@@ -4313,9 +4313,9 @@
       }
     },
     "node_modules/typegram": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-4.2.0.tgz",
-      "integrity": "sha512-rObfoGpDlmWUhmggpWd2I/4xLsdGPDvfvrLpLxV4pBTBL2BBjm+7x7IOmTwJRV6Qe4UAkWdHq0ZYoTYAAPE5YA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-4.3.0.tgz",
+      "integrity": "sha512-pS4STyOZoJ++Mwa9GPMTNjOwEzMkxFfFt1By6IbMOJfheP0utMP/H1ga6J9R4DTjAYBr0UDn4eQg++LpWBvcAg=="
     },
     "node_modules/typescript": {
       "version": "4.9.4",
@@ -7659,9 +7659,9 @@
       }
     },
     "typegram": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-4.2.0.tgz",
-      "integrity": "sha512-rObfoGpDlmWUhmggpWd2I/4xLsdGPDvfvrLpLxV4pBTBL2BBjm+7x7IOmTwJRV6Qe4UAkWdHq0ZYoTYAAPE5YA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-4.3.0.tgz",
+      "integrity": "sha512-pS4STyOZoJ++Mwa9GPMTNjOwEzMkxFfFt1By6IbMOJfheP0utMP/H1ga6J9R4DTjAYBr0UDn4eQg++LpWBvcAg=="
     },
     "typescript": {
       "version": "4.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf",
-  "version": "4.11.2",
+  "version": "4.12.0",
   "description": "Modern Telegram Bot Framework",
   "license": "MIT",
   "author": "Vitaly Domnikov <oss@vitaly.codes>",
@@ -77,7 +77,7 @@
     "p-timeout": "^4.1.0",
     "safe-compare": "^1.1.4",
     "sandwich-stream": "^2.0.2",
-    "typegram": "^4.2.0"
+    "typegram": "^4.3.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/release-notes/4.12.0.md
+++ b/release-notes/4.12.0.md
@@ -1,19 +1,28 @@
 # 4.12.0
 
+## Bot API 6.5 support
+
+- Updated Typegram, added the following Markup.button helpers to request a user or chat:
+  - `Markup.button.userRequest`
+  - `Markup.button.botRequest`
+  - `Markup.button.groupRequest`
+  - `Markup.button.channelRequest`
+- `Telegram::setChatPermissions` and `Context::setChatPermissions` accept a new parameter for `{ use_independent_chat_permissions?: boolean }` as documented in the [API](https://core.telegram.org/bots/api#setchatpermissions).
+
 ## Bot API 6.4 support
 
-* Updated Typegram, added the following new methods to class `Telegram` and `Context`:
-  * `editGeneralForumTopic`
-  * `closeGeneralForumTopic`
-  * `reopenGeneralForumTopic`
-  * `hideGeneralForumTopic`
-  * `unhideGeneralForumTopic`
-* `Context::sendChatAction` will automatically infer `message_thread_id` for topic messages.
-* Fix for `'this' Context of type 'NarrowedContext' is not assignable to method's 'this' of type 'Context<Update>'`.
+- Updated Typegram, added the following new methods to class `Telegram` and `Context`:
+  - `editGeneralForumTopic`
+  - `closeGeneralForumTopic`
+  - `reopenGeneralForumTopic`
+  - `hideGeneralForumTopic`
+  - `unhideGeneralForumTopic`
+- `Context::sendChatAction` will automatically infer `message_thread_id` for topic messages.
+- Fix for `'this' Context of type 'NarrowedContext' is not assignable to method's 'this' of type 'Context<Update>'`.
 
 ## fmt helpers
 
-* New `join` fmt helper to combine dynamic arrays into a single FmtString.
+- New `join` fmt helper to combine dynamic arrays into a single FmtString.
 
   ```TS
   import { fmt, bold, join } from "telegraf/format";
@@ -27,4 +36,4 @@
   });
   ```
 
-* Fixed various bugs in fmt helpers, so things like `bold(italic("telegraf"))` will now work as expected.
+- Fixed various bugs in fmt helpers, so things like `bold(italic("telegraf"))` will now work as expected.

--- a/src/button.ts
+++ b/src/button.ts
@@ -1,4 +1,8 @@
-import { InlineKeyboardButton, KeyboardButton } from './core/types/typegram'
+import {
+  InlineKeyboardButton,
+  KeyboardButton,
+  KeyboardButtonRequestChat,
+} from './core/types/typegram'
 
 type Hideable<B> = B & { hide: boolean }
 
@@ -29,6 +33,63 @@ export function pollRequest(
   hide = false
 ): Hideable<KeyboardButton.RequestPollButton> {
   return { text, request_poll: { type }, hide }
+}
+
+export function userRequest(
+  text: string,
+  /** Must fit in a signed 32 bit int */
+  request_id: number,
+  user_is_premium?: boolean,
+  hide = false
+): Hideable<KeyboardButton.RequestUserButton> {
+  return { text, request_user: { request_id, user_is_premium }, hide }
+}
+
+export function botRequest(
+  text: string,
+  /** Must fit in a signed 32 bit int */
+  request_id: number,
+  hide = false
+): Hideable<KeyboardButton.RequestUserButton> {
+  return { text, request_user: { request_id, user_is_bot: true }, hide }
+}
+
+type KeyboardButtonRequestGroup = Omit<
+  KeyboardButtonRequestChat,
+  'request_id' | 'chat_is_channel'
+>
+
+export function groupRequest(
+  text: string,
+  /** Must fit in a signed 32 bit int */
+  request_id: number,
+  extra?: KeyboardButtonRequestGroup,
+  hide = false
+): Hideable<KeyboardButton.RequestChatButton> {
+  return {
+    text,
+    request_chat: { request_id, chat_is_channel: false, ...extra },
+    hide,
+  }
+}
+
+type KeyboardButtonRequestChannel = Omit<
+  KeyboardButtonRequestChat,
+  'request_id' | 'chat_is_channel' | 'chat_is_forum'
+>
+
+export function channelRequest(
+  text: string,
+  /** Must fit in a signed 32 bit int */
+  request_id: number,
+  extra?: KeyboardButtonRequestChannel,
+  hide = false
+): Hideable<KeyboardButton.RequestChatButton> {
+  return {
+    text,
+    request_chat: { request_id, chat_is_channel: true, ...extra },
+    hide,
+  }
 }
 
 export function url(
@@ -98,6 +159,7 @@ export function webApp(
   text: string,
   url: string,
   hide = false
+  // works as both InlineKeyboardButton and KeyboardButton
 ): Hideable<InlineKeyboardButton.WebAppButton> {
   return {
     text,

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -49,6 +49,10 @@ export type ExtraAnswerInlineQuery = MakeExtra<
   'answerInlineQuery',
   'inline_query_id' | 'results'
 >
+export type ExtraSetChatPermissions = MakeExtra<
+  'setChatPermissions',
+  'permissions'
+>
 export type ExtraAudio = MakeExtra<'sendAudio', 'audio'>
 export type ExtraContact = MakeExtra<
   'sendContact',

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -509,8 +509,16 @@ export class Telegram extends ApiClient {
     })
   }
 
-  setChatPermissions(chatId: number | string, permissions: tg.ChatPermissions) {
-    return this.callApi('setChatPermissions', { chat_id: chatId, permissions })
+  setChatPermissions(
+    chatId: number | string,
+    permissions: tg.ChatPermissions,
+    extra?: tt.ExtraSetChatPermissions
+  ) {
+    return this.callApi('setChatPermissions', {
+      chat_id: chatId,
+      permissions,
+      ...extra,
+    })
   }
 
   /**


### PR DESCRIPTION
- Updated Typegram, added the following Markup.button helpers to request a user or chat:
  - `Markup.button.userRequest`
  - `Markup.button.botRequest`
  - `Markup.button.groupRequest`
  - `Markup.button.channelRequest`
- `Telegram::setChatPermissions` and `Context::setChatPermissions` accept a new parameter for `{ use_independent_chat_permissions?: boolean }` as documented in the [API](https://core.telegram.org/bots/api#setchatpermissions).