### PR TITLE
feat: `Context::persistentChatAction`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -896,8 +896,11 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
       extra?.intervalDuration ?? 4000
     )
 
-    await callback()
-    clearInterval(timer)
+    try {
+      await callback()
+    } finally {
+      clearInterval(timer)
+    }
   }
 
   /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -870,12 +870,12 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
 
   /**
    * @see https://core.telegram.org/bots/api#sendchataction
-   * 
-   * Sends the sendChatAction request repeatedly, with a delay between requests, 
+   *
+   * Sends the sendChatAction request repeatedly, with a delay between requests,
    * as long as the provided callback function is being processed.
-   * 
+   *
    * The sendChatAction errors should be ignored, because the goal is the actual long process completing and performing an action.
-   * 
+   *
    * @param action - chat action type.
    * @param callback - a function to run along with the chat action.
    * @param extra - extra parameters for sendChatAction.

--- a/src/context.ts
+++ b/src/context.ts
@@ -865,18 +865,18 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     })
   }
 
-  persistentChatAction(action: Shorthand<'sendChatAction'>[0], callback: Function, extra?: tt.ExtraSendChatAction) {
+  persistentChatAction(action: Shorthand<'sendChatAction'>[0], callback: () => Promise<void>, extra?: tt.ExtraSendChatAction) {
     return new Promise<void>(async (resolve) => {
       await this.sendChatAction(action, {...extra})
+
       const timer = setInterval(
         async () => await this.sendChatAction(action, {...extra}),
-        8000
+        extra?.intervalDuration ?? 8000
       )
-  
-      await Promise.resolve(callback()).then(async () => {
-        clearInterval(timer)
-        resolve()
-      })
+        
+      await callback();
+      clearInterval(timer);
+      resolve();
     })
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,6 +5,9 @@ import ApiClient from './core/network/client'
 import { Guard, Guarded, MaybeArray } from './util'
 import Telegram from './telegram'
 import { FmtString } from './format'
+import d from 'debug'
+
+const debug = d('telegraf:context')
 
 type Tail<T> = T extends [unknown, ...infer U] ? U : never
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -859,7 +859,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
    */
   sendChatAction(
     action: Shorthand<'sendChatAction'>[0],
-    extra?: Omit<tt.ExtraSendChatAction, 'intervalDuration'>
+    extra?: tt.ExtraSendChatAction
   ) {
     this.assert(this.chat, 'sendChatAction')
     return this.telegram.sendChatAction(this.chat.id, action, {

--- a/src/context.ts
+++ b/src/context.ts
@@ -856,7 +856,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
    */
   sendChatAction(
     action: Shorthand<'sendChatAction'>[0],
-    extra?: tt.ExtraSendChatAction
+    extra?: Omit<tt.ExtraSendChatAction, 'intervalDuration'>
   ) {
     this.assert(this.chat, 'sendChatAction')
     return this.telegram.sendChatAction(this.chat.id, action, {

--- a/src/context.ts
+++ b/src/context.ts
@@ -888,15 +888,16 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   ) {
     await this.sendChatAction(action, { ...extra })
 
-      const timer = setInterval(
-        async () => await this.sendChatAction(action, {...extra}),
-        extra?.intervalDuration ?? 8000
-      )
-        
-      await callback();
-      clearInterval(timer);
-      resolve();
-    })
+    const timer = setInterval(
+      async () =>
+        await this.sendChatAction(action, { ...extra }).catch((err) => {
+          debug('Ignored error while persisting sendChatAction:', err)
+        }),
+      extra?.intervalDuration ?? 8000
+    )
+
+    await callback()
+    clearInterval(timer)
   }
 
   /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -892,11 +892,11 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     await this.sendChatAction(action, { ...extra })
 
     const timer = setInterval(
-      async () =>
-        await this.sendChatAction(action, { ...extra }).catch((err) => {
+      () =>
+        this.sendChatAction(action, { ...extra }).catch((err) => {
           debug('Ignored error while persisting sendChatAction:', err)
         }),
-      extra?.intervalDuration ?? 4000
+      intervalDuration ?? 4000
     )
 
     try {

--- a/src/context.ts
+++ b/src/context.ts
@@ -865,6 +865,21 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     })
   }
 
+  persistentChatAction(action: Shorthand<'sendChatAction'>[0], callback: Function, extra?: tt.ExtraSendChatAction) {
+    return new Promise<void>(async (resolve) => {
+      await this.sendChatAction(action, {...extra})
+      const timer = setInterval(
+        async () => await this.sendChatAction(action, {...extra}),
+        8000
+      )
+  
+      await Promise.resolve(callback()).then(async () => {
+        clearInterval(timer)
+        resolve()
+      })
+    })
+  }
+
   /**
    * @deprecated use {@link Context.sendChatAction} instead
    * @see https://core.telegram.org/bots/api#sendchataction

--- a/src/context.ts
+++ b/src/context.ts
@@ -884,7 +884,10 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   async persistentChatAction(
     action: Shorthand<'sendChatAction'>[0],
     callback: () => Promise<void>,
-    extra?: tt.ExtraSendChatAction & { intervalDuration?: number }
+    {
+      intervalDuration,
+      ...extra
+    }: tt.ExtraSendChatAction & { intervalDuration?: number } = {}
   ) {
     await this.sendChatAction(action, { ...extra })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -868,9 +868,25 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
     })
   }
 
-  persistentChatAction(action: Shorthand<'sendChatAction'>[0], callback: () => Promise<void>, extra?: tt.ExtraSendChatAction) {
-    return new Promise<void>(async (resolve) => {
-      await this.sendChatAction(action, {...extra})
+  /**
+   * @see https://core.telegram.org/bots/api#sendchataction
+   * 
+   * Sends the sendChatAction request repeatedly, with a delay between requests, 
+   * as long as the provided callback function is being processed.
+   * 
+   * The sendChatAction errors should be ignored, because the goal is the actual long process completing and performing an action.
+   * 
+   * @param action - chat action type.
+   * @param callback - a function to run along with the chat action.
+   * @param extra - extra parameters for sendChatAction.
+   * @param {number} [extra.intervalDuration=8000] - The duration (in milliseconds) between subsequent sendChatAction requests.
+   */
+  async persistentChatAction(
+    action: Shorthand<'sendChatAction'>[0],
+    callback: () => Promise<void>,
+    extra?: tt.ExtraSendChatAction & { intervalDuration?: number }
+  ) {
+    await this.sendChatAction(action, { ...extra })
 
       const timer = setInterval(
         async () => await this.sendChatAction(action, {...extra}),

--- a/src/context.ts
+++ b/src/context.ts
@@ -893,7 +893,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
         await this.sendChatAction(action, { ...extra }).catch((err) => {
           debug('Ignored error while persisting sendChatAction:', err)
         }),
-      extra?.intervalDuration ?? 8000
+      extra?.intervalDuration ?? 4000
     )
 
     await callback()

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,7 @@
 import { FmtString } from './format'
+import { ChatAction } from './core/types/typegram'
+import { ExtraSendChatAction } from './telegram-types'
+import { Context } from './context'
 
 export const env = process.env
 
@@ -60,4 +63,24 @@ export function* zip<X, Y>(xs: Iterable<X>, ys: Iterable<Y>): Iterable<X | Y> {
     yield y1.value
     y1 = y.next()
   }
+}
+
+export async function persistentChatAction(
+  ctx: Context,
+  callback: () => Promise<void>,
+  action: ChatAction, 
+  every: number = 8000
+) {
+  return new Promise<void>(async (resolve) => {
+    await ctx.sendChatAction(action)
+
+    const timer = setInterval(
+      async () => await ctx.sendChatAction(action),
+      every
+    )
+
+    await callback()
+    clearInterval(timer)
+    resolve()
+  })
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,7 +68,7 @@ export function* zip<X, Y>(xs: Iterable<X>, ys: Iterable<Y>): Iterable<X | Y> {
 export async function persistentChatAction(
   ctx: Context,
   callback: () => Promise<void>,
-  action: ChatAction, 
+  action: ChatAction,
   every: number = 8000
 ) {
   return new Promise<void>(async (resolve) => {
@@ -82,5 +82,21 @@ export async function persistentChatAction(
     await callback()
     clearInterval(timer)
     resolve()
+  })
+}
+
+export async function timedChatAction(ctx: any, action: ChatAction, duration: number, every?: number) {
+  return new Promise<void>(async (resolve) => {
+    await ctx.sendChatAction(action)
+
+    const timer = setInterval(
+      async () => await ctx.sendChatAction(action),
+      every ?? 8000
+    )
+
+    setTimeout(async () => {
+      clearInterval(timer)
+      resolve()
+    }, duration)
   })
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,4 @@
 import { FmtString } from './format'
-import { ChatAction } from './core/types/typegram'
-import { ExtraSendChatAction } from './telegram-types'
-import { Context } from './context'
 
 export const env = process.env
 
@@ -63,40 +60,4 @@ export function* zip<X, Y>(xs: Iterable<X>, ys: Iterable<Y>): Iterable<X | Y> {
     yield y1.value
     y1 = y.next()
   }
-}
-
-export async function persistentChatAction(
-  ctx: Context,
-  callback: () => Promise<void>,
-  action: ChatAction,
-  every: number = 8000
-) {
-  return new Promise<void>(async (resolve) => {
-    await ctx.sendChatAction(action)
-
-    const timer = setInterval(
-      async () => await ctx.sendChatAction(action),
-      every
-    )
-
-    await callback()
-    clearInterval(timer)
-    resolve()
-  })
-}
-
-export async function timedChatAction(ctx: any, action: ChatAction, duration: number, every?: number) {
-  return new Promise<void>(async (resolve) => {
-    await ctx.sendChatAction(action)
-
-    const timer = setInterval(
-      async () => await ctx.sendChatAction(action),
-      every ?? 8000
-    )
-
-    setTimeout(async () => {
-      clearInterval(timer)
-      resolve()
-    }, duration)
-  })
 }


### PR DESCRIPTION
Fixes #1801

# Description
This pull request introduces a new feature to allow for the continuous sending of chat action requests while running long processes, in order to improve the user experience with bots.

The `persistentChatAction` utility sends the `sendChatAction` request repeatedly, with a delay between requests, as long as the provided callback function is being processed. This gives the user a sense of the bot's responsiveness while they wait for a long process to complete. To use this utility, simply call `persistentChatAction` with the `ctx` object (or as a utility), the chat action type (e.g. 'typing'), and the long process as a callback function.

To use the feature, there are two ways:
As @MKRhere suggested:
```ts
bot.start(async (ctx) => {
  persistentChatAction(
    ctx,
    async () => {
      // some prolonged actions...
      await ctx.reply('done')
    },
    'typing'
  )
})
```

As @wojpawlik suggested:
```ts
bot.start(async (ctx) => {
  await ctx.persistentChatAction('typing', async () => {
    // some prolonged actions...
    await ctx.reply('done')
  })
})
```

Alternatively, you can use the `timedChatAction` utility to send a chat action continuously for a specified amount of time. 
To use this utility, simply call `timedChatAction` with the `ctx` object, the chat action type, and the duration in milliseconds. For example:

```ts
bot.start(async ctx => {
    await timedChatAction(ctx, "typing", 10000) // "typing" for 10 seconds 
    // some code...
})
```


I have tested the implementation and it works as expected.

I would appreciate feedback from you, including any potential issues or ideas for improvement. I am open to collaboration and willing to work with you to ensure that this feature meets your standards and benefits the community.

Thank you for considering this feature.