### PR TITLE
fix: Missing type for param in editMessageText

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -277,7 +277,7 @@ export class Context<U extends Deunionize<tg.Update> = tg.Update> {
   /**
    * @see https://core.telegram.org/bots/api#editmessagetext
    */
-  editMessageText(text: string, extra?: tt.ExtraEditMessageText) {
+  editMessageText(text: string | FmtString, extra?: tt.ExtraEditMessageText) {
     this.assert(this.callbackQuery ?? this.inlineMessageId, 'editMessageText')
     return this.telegram.editMessageText(
       this.chat?.id,


### PR DESCRIPTION
The `text` param in the `editMessageText` function can be either `string` or `FmtString`