### PR TITLE
feat: custom property in sessions

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -26,6 +26,7 @@ interface SessionOptions<S, C extends Context, P extends string> {
   defaultSession?: (ctx: C) => S
 }
 
+/** @deprecated session can use custom properties now. Construct this type directly. */
 export interface SessionContext<S extends object> extends Context {
   session?: S
 }
@@ -185,6 +186,7 @@ export class MemorySessionStore<T> implements SyncSessionStore<T> {
   }
 }
 
+/** @deprecated session can use custom properties now. Directly use `'session' in ctx` instead */
 export function isSessionContext<S extends object>(
   ctx: Context
 ): ctx is SessionContext<S> {

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,5 @@
 import { Context } from './context'
-import { MaybePromise } from './util'
+import { ExclusiveKeys, MaybePromise } from './util'
 import { MiddlewareFn } from './middleware'
 import d from 'debug'
 const debug = d('telegraf:session')
@@ -18,7 +18,9 @@ export interface AsyncSessionStore<T> {
 
 export type SessionStore<T> = SyncSessionStore<T> | AsyncSessionStore<T>
 
-interface SessionOptions<S extends object, C extends Context = Context> {
+interface SessionOptions<S, C extends Context, P extends string> {
+  /** Customise the session prop. Defaults to "session" and is available as ctx.session. */
+  property?: P
   getSessionKey?: (ctx: C) => Promise<string | undefined>
   store?: SessionStore<S>
   defaultSession?: (ctx: C) => S
@@ -36,15 +38,20 @@ export interface SessionContext<S extends object> extends Context {
  *
  * > ⚠️ Session data is kept only in memory by default,  which means that all data will be lost when the process is terminated.
  * >
- * > If you want to store data across restarts, or share it among workers, you should use
+ * > If you want to persist data across process restarts, or share it among multiple instances, you should use
  * [@telegraf/session](https://www.npmjs.com/package/@telegraf/session), or pass custom `storage`.
  *
  * @see {@link https://github.com/feathers-studio/telegraf-docs/blob/b694bcc36b4f71fb1cd650a345c2009ab4d2a2a5/guide/session.md Telegraf Docs | Session}
  * @see {@link https://github.com/feathers-studio/telegraf-docs/blob/master/examples/session-bot.ts Example}
  */
-export function session<S extends object, C extends Context = Context>(
-  options?: SessionOptions<S, C>
-): MiddlewareFn<C & { session?: S }> {
+export function session<
+  S extends NonNullable<C[P]>,
+  C extends Context & { [key in P]?: C[P] },
+  P extends (ExclusiveKeys<C, Context> & string) | 'session' = 'session'
+  // ^ Only allow prop names that aren't keys in base Context.
+  // At type level, this is cosmetic. To not get cluttered with all Context keys.
+>(options?: SessionOptions<S, C, P>): MiddlewareFn<C> {
+  const prop = options?.property ?? ('session' as P)
   const getSessionKey = options?.getSessionKey ?? defaultGetSessionKey
   const store = options?.store ?? new MemorySessionStore()
   // caches value from store in-memory while simultaneous updates share it
@@ -63,7 +70,8 @@ export function session<S extends object, C extends Context = Context>(
     // v5 getSessionKey should probably be synchronous to avoid that
     const key = await getSessionKey(ctx)
     if (!key) {
-      ctx.session = undefined
+      // Leaving this here could be useful to check for `prop in ctx` in future middleware
+      ctx[prop] = undefined as unknown as S
       return await next()
     }
 
@@ -107,7 +115,7 @@ export function session<S extends object, C extends Context = Context>(
 
     let touched = false
 
-    Object.defineProperty(ctx, 'session', {
+    Object.defineProperty(ctx, prop, {
       get() {
         touched = true
         return c.ref
@@ -130,12 +138,12 @@ export function session<S extends object, C extends Context = Context>(
 
       // only update store if ctx.session was touched
       if (touched)
-        if (ctx.session == null) {
-          debug(`(${updId}) ctx.session missing, removing from store`)
+        if (ctx[prop] == null) {
+          debug(`(${updId}) ctx.${prop} missing, removing from store`)
           await store.delete(key)
         } else {
-          debug(`(${updId}) ctx.session found, updating store`)
-          await store.set(key, ctx.session)
+          debug(`(${updId}) ctx.${prop} found, updating store`)
+          await store.set(key, ctx[prop] as S)
         }
     }
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -21,7 +21,7 @@ export type SessionStore<T> = SyncSessionStore<T> | AsyncSessionStore<T>
 interface SessionOptions<S, C extends Context, P extends string> {
   /** Customise the session prop. Defaults to "session" and is available as ctx.session. */
   property?: P
-  getSessionKey?: (ctx: C) => Promise<string | undefined>
+  getSessionKey?: (ctx: C) => MaybePromise<string | undefined>
   store?: SessionStore<S>
   defaultSession?: (ctx: C) => S
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,6 +15,9 @@ export type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
 export type NonemptyReadonlyArray<T> = readonly [T, ...T[]]
 
+// prettier-ignore
+export type ExclusiveKeys<A extends object, B extends object> = keyof Omit<A, keyof B>
+
 export function fmtCaption<
   Extra extends { caption?: string | FmtString } | undefined
 >(

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -29,8 +29,8 @@ const Fixtures = {
       message: {
         message_id: message_id++,
         date: Date.now(),
-        from,
-        chat,
+        from: { ...from },
+        chat: { ...chat },
         text: 'foo',
       },
     }),

--- a/test/session.js
+++ b/test/session.js
@@ -54,19 +54,17 @@ test('must resist session racing (with sync store)', (t) =>
       // pretend there are other middlewares that slow down by a random amount
       bot.use(genericAsyncMiddleware)
 
-      Promise.all(
+      return Promise.all(
         Array
           // create 100 text updates and fire them all at once
           .from({ length: 100 }, Fixtures.message.text)
           .map((fixture) => bot.handleUpdate(fixture))
-      ).then(() => {
-        const entries = [...map.entries()]
-        t.deepEqual(entries.length, 1)
-        const [key, value] = entries[0]
-        t.deepEqual(key, '1:1')
-        t.deepEqual(value, { count: 100 })
-        resolve(true)
-      })
+      )
+        .then(() => {
+          t.deepEqual(map.size, 1)
+          t.deepEqual(map.get('1:1'), { count: 100 })
+        })
+        .then(() => resolve(true))
     })
   ))
 
@@ -107,29 +105,21 @@ test('must resist session racing (with async store)', (t) =>
       // pretend there are other middlewares that slow down by a random amount
       bot.use(genericAsyncMiddleware)
 
-      Promise.all(
+      return Promise.all(
         Array
           // create 100 text updates and fire them all at once
           .from({ length: 100 }, Fixtures.message.text)
           .map((fixture) => bot.handleUpdate(fixture))
-      ).then(() => {
-        const entries = [...map.entries()]
-        t.deepEqual(entries.length, 1)
-        const [key, value] = entries[0]
-        t.deepEqual(key, '1:1')
-        t.deepEqual(value, { count: 100 })
-        resolve(true)
-      })
+      )
+        .then(() => {
+          t.deepEqual(map.size, 1)
+          t.deepEqual(map.get('1:1'), { count: 100 })
+        })
+        .then(() => resolve(true))
     })
   ))
 
-/*
-
-This test is the same as above, but a defaultSession is passed.
-It tests that defaultSession is not erraneously stored in the db when it's not used.
-
-*/
-test('must not write default session back if session not touched', (t) =>
+test('must not write session back if session not touched after defaultSession was passed', (t) =>
   t.notThrowsAsync(
     new Promise((resolve) => {
       /** @type {import('..').Telegraf<MyCtx>} */
@@ -145,26 +135,18 @@ test('must not write default session back if session not touched', (t) =>
         // ctx.session is not touched
       })
 
-      Promise.all(
+      return Promise.all(
         Array
           // create 100 text message updates and fire them all at once
           .from({ length: 100 }, Fixtures.message.text)
           .map((fixture) => bot.handleUpdate(fixture))
-      ).then(() => {
-        const entries = [...map.entries()]
-        t.deepEqual(entries.length, 0)
-        resolve(true)
-      })
+      )
+        .then(() => t.deepEqual(map.size, 0))
+        .then(() => resolve(true))
     })
   ))
 
-/*
-
-This test is the same as above, but a defaultSession is passed.
-It tests that defaultSession is not erraneously stored in the db when it's not used.
-
-*/
-test('must write default session back if session was touched', (t) =>
+test('must write session back if session was touched after defaultSession is passed', (t) =>
   t.notThrowsAsync(
     new Promise((resolve) => {
       /** @type {import('..').Telegraf<MyCtx>} */
@@ -179,7 +161,7 @@ test('must write default session back if session was touched', (t) =>
         await randSleep(200)
       })
 
-      Promise.all(
+      return Promise.all(
         Array
           // create 100 text message updates and fire them all at once
           .from({ length: 100 }, Fixtures.message.text)
@@ -192,5 +174,62 @@ test('must write default session back if session was touched', (t) =>
         t.deepEqual(value, { count: 100 })
         resolve(true)
       })
+    })
+  ))
+
+test('multiple sessions can be used independently without conflict', (t) =>
+  t.notThrowsAsync(
+    new Promise((resolve) => {
+      /** @type {import('..').Telegraf<MyCtx & { chatSession: { chatCount: number } }>} */
+      const bot = createBot()
+
+      const { store, map } = SyncStore()
+
+      // first session, ctx.session
+      bot.use(
+        session({
+          store,
+          defaultSession: () => ({ count: 0 }),
+        })
+      )
+
+      const { store: chatStore, map: chatStoreMap } = SyncStore()
+
+      // second session, ctx.chatSession
+      bot.use(
+        session({
+          property: 'chatSession',
+          getSessionKey: (ctx) => ctx.chat && String(ctx.chat.id),
+          store: chatStore,
+          defaultSession: () => ({ chatCount: 0 }),
+        })
+      )
+
+      bot.on('message', async (ctx) => {
+        ctx.session.count++
+        ctx.chatSession.chatCount++
+        // pretend we make an API call, etc
+        await randSleep(200)
+      })
+
+      return Promise.all(
+        Array
+          // create 100 text message updates and fire them all at once
+          .from({ length: 100 }, Fixtures.message.text)
+          // get different chatIds
+          .map((fixture, id) => ((fixture.message.chat.id = id), fixture))
+          .map((fixture) => bot.handleUpdate(fixture))
+      )
+        .then(() => {
+          t.deepEqual(map.size, 100)
+          for (let chatId = 0; chatId < 100; chatId++)
+            t.deepEqual(map.get(`1:${chatId}`), { count: 1 })
+        })
+        .then(() => {
+          t.deepEqual(chatStoreMap.size, 100)
+          for (let chatId = 0; chatId < 100; chatId++)
+            t.deepEqual(chatStoreMap.get(String(chatId)), { chatCount: 1 })
+        })
+        .then(() => resolve(true))
     })
   ))


### PR DESCRIPTION
Long ago, Telegraf had the ability to specify custom property name while creating session. [This was lost `51dfca`](https://github.com/telegraf/telegraf/commit/51dfca4e3df3cdcc0ab785ad5ce0f3e1210ccbf4) because it was deemed too hard to write types for in v4. However, with this PR, we regain this ability in full.

Although the usage below seems like a trivial addition, this took several days and at least one sleepless night to type correctly. Thanks for the patience!

### Usage

```TS
// defaults to ctx.session
bot.use(session({ defaultSession: () => ({}) }));

bot.use(session({
	property: "chatSession",
	getSessionKey: ctx => String(ctx.chat.id),
	defaultSession: () => ({ count: 0 }),
}));

bot.on("message", ctx => {
	ctx.session.seen = true;
});

bot.on("message", ctx => {
	ctx.chatSession.count++;
});
```

I'm still investigating Stage/Scene support for custom properties.

Fixes #1824