### PR TITLE
fix: Fixed bot.launch() process stopping using await

### DIFF
--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -275,7 +275,7 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
         drop_pending_updates: config.dropPendingUpdates,
       })
       debug('Bot started with long polling')
-      await this.startPolling(config.allowedUpdates)
+      this.startPolling(config.allowedUpdates)
       return
     }
 


### PR DESCRIPTION
An unnecessary `await` in the code prevented `bot.launch()` from returning the promise.
Issue: https://github.com/telegraf/telegraf/issues/1749