### PR TITLE
Add default chatId in defaultGetSessionKey

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -164,7 +164,7 @@ export function session<
 
 function defaultGetSessionKey(ctx: Context): string | undefined {
   const fromId = ctx.from?.id
-  const chatId = ctx.chat?.id
+  const chatId = ctx.chat?.id || fromId
   if (fromId == null || chatId == null) return undefined
   return `${fromId}:${chatId}`
 }


### PR DESCRIPTION
I didn't understand why `chatId` must not be same as `fromId` if `chatId` is not provided. This fix is needed for `pre_checkout_query`, cause there is no `chatId` provided.