### PR TITLE
Fix getFileLink in test environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telegraf",
-  "version": "4.14.0",
+  "version": "4.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "telegraf",
-      "version": "4.14.0",
+      "version": "4.15.3",
       "license": "MIT",
       "dependencies": {
         "@telegraf/types": "^6.9.1",

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -42,8 +42,10 @@ export class Telegram extends ApiClient {
     }
 
     return new URL(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      `./file/${this.options.apiMode}${this.token}${this.options.testEnv ? '/test' : ''}/${fileId.file_path!}`,
+      `./file/${this.options.apiMode}${this.token}${
+        this.options.testEnv ? '/test' : ''
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      }/${fileId.file_path!}`,
       this.options.apiRoot
     )
   }

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -43,7 +43,7 @@ export class Telegram extends ApiClient {
 
     return new URL(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      `./file/${this.options.apiMode}${this.token}/${fileId.file_path!}`,
+      `./file/${this.options.apiMode}${this.token}${this.options.testEnv ? '/test' : ''}/${fileId.file_path!}`,
       this.options.apiRoot
     )
   }


### PR DESCRIPTION
When working in test environment, file links must have `/test` before file path