### PR TITLE
feat: API changes for 7.3-7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.16.3",
       "license": "MIT",
       "dependencies": {
-        "@telegraf/types": "^7.1.0",
+        "@telegraf/types": "danielrhodes/telegraf-types#feat/api-7.8",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.4",
         "mri": "^1.2.0",
@@ -613,9 +613,8 @@
       }
     },
     "node_modules/@telegraf/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw=="
+      "version": "7.8.0",
+      "resolved": "git+ssh://git@github.com/danielrhodes/telegraf-types.git#b772c033f568c137bfa239c368eb07d1057164ca"
     },
     "node_modules/@types/debug": {
       "version": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf",
-  "version": "4.16.3",
+  "version": "4.17.0",
   "description": "Modern Telegram Bot Framework",
   "license": "MIT",
   "author": "The Telegraf Contributors",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "types": "./typings/index.d.ts",
   "dependencies": {
-    "@telegraf/types": "^7.1.0",
+    "@telegraf/types": "danielrhodes/telegraf-types#feat/api-7.8",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.4",
     "mri": "^1.2.0",

--- a/src/core/types/typegram.ts
+++ b/src/core/types/typegram.ts
@@ -44,6 +44,7 @@ export type InputMediaVideo = Typegram.InputMediaVideo<InputFile>
 export type InputMediaAnimation = Typegram.InputMediaAnimation<InputFile>
 export type InputMediaAudio = Typegram.InputMediaAudio<InputFile>
 export type InputMediaDocument = Typegram.InputMediaDocument<InputFile>
+export type InputPaidMedia = Typegram.InputPaidMedia<InputFile>
 
 // tiny helper types
 export type ChatAction = Opts<'sendChatAction'>['action']

--- a/src/telegram-types.ts
+++ b/src/telegram-types.ts
@@ -135,6 +135,7 @@ export type ExtraVenue = MakeExtra<
 export type ExtraVideo = MakeExtra<'sendVideo', 'video'>
 export type ExtraVideoNote = MakeExtra<'sendVideoNote', 'video_note'>
 export type ExtraVoice = MakeExtra<'sendVoice', 'voice'>
+export type ExtraPaidMedia = MakeExtra<'sendPaidMedia', 'media' | 'star_count'>
 export type ExtraBanChatSenderChat = MakeExtra<
   'banChatSenderChat',
   'sender_chat_id'

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -427,6 +427,27 @@ export class Telegram extends ApiClient {
   }
 
   /**
+   * Send paid media to channel chats. On success, the sent Message is returned.
+   * @param chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+   * @param media A JSON-serialized array describing photos and videos to be sent, must include up to 10 items.
+   * @param starCount The number of Telegram Stars that must be paid to buy access to the media
+   * @param extra Additional parameters for the message.
+   */
+  sendPaidMedia(
+    chatId: number | string,
+    media: tg.Opts<'sendPaidMedia'>['media'],
+    starCount: number,
+    extra?: tt.ExtraPaidMedia
+  ) {
+    return this.callApi('sendPaidMedia', {
+      chat_id: chatId,
+      media,
+      star_count: starCount,
+      ...fmtCaption(extra),
+    })
+  }
+
+  /**
    * @param chatId Unique identifier for the target chat
    * @param gameShortName Short name of the game, serves as the unique identifier for the game. Set up your games via Botfather.
    */
@@ -1621,6 +1642,27 @@ export class Telegram extends ApiClient {
   }: { forChannels?: boolean } = {}) {
     return this.callApi('getMyDefaultAdministratorRights', {
       for_channels: forChannels,
+    })
+  }
+
+  /**
+   * Returns the bot's Telegram Star transactions in chronological order.
+   * @param offset
+   * @param limit
+   * @returns StarTransactions
+   */
+  getStarTransactions(offset?: number, limit?: number) {
+    return this.callApi('getStarTransactions', { offset, limit })
+  }
+
+  /**
+   * Refunds a successful payment in Telegram Stars.
+   * @returns true on success
+   */
+  refundStarPayment(userId: number, telegramPaymentChargeId: number) {
+    return this.callApi('refundStarPayment', {
+      user_id: userId,
+      telegram_payment_charge_id: telegramPaymentChargeId,
     })
   }
 


### PR DESCRIPTION
This adds support for the additional methods in the Telegram [changelog](https://core.telegram.org/bots/api-changelog). 

Paired with https://github.com/telegraf/types/pull/6

Note: package.json is wired into my fork of the types for now - should change it back before merging.