### PR TITLE
Fix for Attempted to assign to readonly property (at redactToken).

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -294,8 +294,11 @@ async function answerToWebhook(
 function redactToken(error: Error): Promise<never> {
   return Promise.reject(
     new Error(
-      error?.message?.replace(/\/(bot|user)(\d+):[^/]+\//, '/$1$2:[REDACTED]/')
-    ) ?? 'Unknown error'
+      error?.message?.replace(
+        /\/(bot|user)(\d+):[^/]+\//,
+        '/$1$2:[REDACTED]/'
+      ) ?? 'Unknown error'
+    )
   )
 }
 

--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -291,12 +291,12 @@ async function answerToWebhook(
   return true
 }
 
-function redactToken(error: Error): never {
-  error.message = error.message.replace(
-    /\/(bot|user)(\d+):[^/]+\//,
-    '/$1$2:[REDACTED]/'
+function redactToken(error: Error): Promise<never> {
+  return Promise.reject(
+    new Error(
+      error?.message?.replace(/\/(bot|user)(\d+):[^/]+\//, '/$1$2:[REDACTED]/')
+    ) ?? 'Unknown error'
   )
-  throw error
 }
 
 type Response = http.ServerResponse


### PR DESCRIPTION
Fix for [redactToken](https://github.com/telegraf/telegraf/blob/0638cf4cc7ba8467ccb9222726024c99c54d119f/src/core/network/client.ts#L294) function which won't work on modern NodeJS and Bun

```json
{
  "message": "Attempted to assign to readonly property.",
  "originalLine": 264,
  "originalColumn": 10,
  "line": 235,
  "column": 5,
  "sourceURL": "/app/node_modules/telegraf/lib/core/network/client.js",
  "stack": "TypeError: Attempted to assign to readonly property.\n    at redactToken (/app/node_modules/telegraf/lib/core/network/client.js:235:5)\n    at processTicksAndRejections (native:7:39)"
}
```

See: https://github.com/telegraf/telegraf/issues/2078