### PR TITLE
fix: return appropriate HTTP status codes in webhook responses

### DIFF
--- a/src/core/network/webhook.ts
+++ b/src/core/network/webhook.ts
@@ -3,15 +3,35 @@ import d from 'debug'
 import { type Update } from '../types/typegram'
 const debug = d('telegraf:webhook')
 
+export interface WebhookOptions {
+  /**
+   * Expected webhook path for proper status code responses.
+   * When provided, enables returning 404 for path mismatches
+   * and 405 for method mismatches instead of generic 403.
+   */
+  path?: string
+}
+
 export default function generateWebhook(
   filter: (req: http.IncomingMessage) => boolean,
-  updateHandler: (update: Update, res: http.ServerResponse) => Promise<void>
+  updateHandler: (update: Update, res: http.ServerResponse) => Promise<void>,
+  options?: WebhookOptions
 ) {
   return async (
     req: http.IncomingMessage & { body?: Update },
     res: http.ServerResponse,
     next = (): void => {
-      res.statusCode = 403
+      // Use appropriate HTTP status codes based on rejection reason
+      if (req.method !== 'POST') {
+        // 405 Method Not Allowed for non-POST requests
+        res.statusCode = 405
+      } else if (options?.path && req.url !== options.path) {
+        // 404 Not Found for path mismatches
+        res.statusCode = 404
+      } else {
+        // 403 Forbidden for authentication failures (secret token mismatch)
+        res.statusCode = 403
+      }
       debug('Replying with status code', res.statusCode)
       res.end()
     }

--- a/src/telegraf.ts
+++ b/src/telegraf.ts
@@ -184,7 +184,8 @@ export class Telegraf<C extends Context = Context> extends Composer<C> {
     return generateCallback(
       this.webhookFilter.bind({ hookPath: path, path, secretToken }),
       (update: tg.Update, res: http.ServerResponse) =>
-        this.handleUpdate(update, res)
+        this.handleUpdate(update, res),
+      { path }
     )
   }
 

--- a/test/telegraf.js
+++ b/test/telegraf.js
@@ -275,3 +275,45 @@ test('ctx.entities() should return only requested entities', (t) => {
     },
   })
 })
+
+// Webhook status code tests
+test('webhookCallback should return 405 for non-POST requests', async (t) => {
+  const bot = createBot()
+  const callback = bot.webhookCallback('/webhook')
+  const req = {
+    method: 'GET',
+    url: '/webhook',
+    headers: {},
+  }
+  const res = new MockResponse()
+  await callback(req, res)
+  t.is(res.statusCode, 405)
+})
+
+test('webhookCallback should return 404 for path mismatch', async (t) => {
+  const bot = createBot()
+  const callback = bot.webhookCallback('/webhook')
+  const req = {
+    method: 'POST',
+    url: '/wrong-path',
+    headers: {},
+  }
+  const res = new MockResponse()
+  await callback(req, res)
+  t.is(res.statusCode, 404)
+})
+
+test('webhookCallback should return 403 for secret token mismatch', async (t) => {
+  const bot = createBot()
+  const callback = bot.webhookCallback('/webhook', { secretToken: 'mysecret' })
+  const req = {
+    method: 'POST',
+    url: '/webhook',
+    headers: {
+      'x-telegram-bot-api-secret-token': 'wrongsecret',
+    },
+  }
+  const res = new MockResponse()
+  await callback(req, res)
+  t.is(res.statusCode, 403)
+})


### PR DESCRIPTION
## Summary

This PR fixes #2065 by returning appropriate HTTP status codes when webhook requests are rejected:

- **405 Method Not Allowed** for non-POST requests
- **404 Not Found** for webhook path mismatches  
- **403 Forbidden** for secret token mismatches (unchanged behavior)

Previously, all rejection scenarios returned 403 Forbidden, which confused clients into thinking there was an authentication issue when the problem was actually a method or path mismatch.

## Changes

1. **`src/core/network/webhook.ts`**: Added optional `WebhookOptions` parameter with `path` property. The default `next` callback now determines the appropriate status code based on:
   - Whether the request method is POST (405 if not)
   - Whether the path matches (404 if it doesn't)
   - Otherwise assumes authentication failure (403)

2. **`src/telegraf.ts`**: Updated `webhookCallback()` to pass the expected path to `generateCallback`.

3. **`test/telegraf.js`**: Added three test cases to verify the new status code behavior.

## Backward Compatibility

This change is backward compatible:
- The `WebhookOptions` parameter is optional
- Custom `webhookFilter` implementations still work (they return boolean as before)
- The filter logic itself is unchanged - only the rejection status codes are now more specific

## Testing

All existing tests pass, plus 3 new tests for the status code behavior:
- `webhookCallback should return 405 for non-POST requests`
- `webhookCallback should return 404 for path mismatch`  
- `webhookCallback should return 403 for secret token mismatch`