### PR TITLE
fix: add type predicate return types to Msg methods

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1534,10 +1534,12 @@ interface Msg {
 }
 
 const Msg: Msg = {
-  isAccessible() {
+  isAccessible(): this is MaybeMessage<tg.Message> {
     return 'date' in this && this.date !== 0
   },
-  has(...keys) {
+  has<Ks extends UnionKeys<tg.Message>[]>(
+    ...keys: Ks
+  ): this is MaybeMessage<Keyed<tg.Message, Ks[number]>> {
     return keys.some(
       (key) =>
         // @ts-expect-error TS doesn't understand key
@@ -1553,14 +1555,14 @@ export type MaybeMessage<
 type GetMsg<U extends tg.Update> = U extends tg.Update.MessageUpdate
   ? U['message']
   : U extends tg.Update.ChannelPostUpdate
-  ? U['channel_post']
-  : U extends tg.Update.EditedChannelPostUpdate
-  ? U['edited_channel_post']
-  : U extends tg.Update.EditedMessageUpdate
-  ? U['edited_message']
-  : U extends tg.Update.CallbackQueryUpdate
-  ? U['callback_query']['message']
-  : undefined
+    ? U['channel_post']
+    : U extends tg.Update.EditedChannelPostUpdate
+      ? U['edited_channel_post']
+      : U extends tg.Update.EditedMessageUpdate
+        ? U['edited_message']
+        : U extends tg.Update.CallbackQueryUpdate
+          ? U['callback_query']['message']
+          : undefined
 
 function getMessageFromAnySource<U extends tg.Update>(ctx: Context<U>) {
   const msg =
@@ -1577,20 +1579,20 @@ type GetUserFromAnySource<U extends tg.Update> =
   GetMsg<U> extends { from: tg.User }
     ? tg.User
     : U extends  // these updates have `from`
-        | tg.Update.CallbackQueryUpdate
-        | tg.Update.InlineQueryUpdate
-        | tg.Update.ShippingQueryUpdate
-        | tg.Update.PreCheckoutQueryUpdate
-        | tg.Update.ChosenInlineResultUpdate
-        | tg.Update.ChatMemberUpdate
-        | tg.Update.MyChatMemberUpdate
-        | tg.Update.ChatJoinRequestUpdate
-        // these updates have `user`
-        | tg.Update.MessageReactionUpdate
-        | tg.Update.PollAnswerUpdate
-        | tg.Update.ChatBoostUpdate
-    ? tg.User
-    : undefined
+          | tg.Update.CallbackQueryUpdate
+          | tg.Update.InlineQueryUpdate
+          | tg.Update.ShippingQueryUpdate
+          | tg.Update.PreCheckoutQueryUpdate
+          | tg.Update.ChosenInlineResultUpdate
+          | tg.Update.ChatMemberUpdate
+          | tg.Update.MyChatMemberUpdate
+          | tg.Update.ChatJoinRequestUpdate
+          // these updates have `user`
+          | tg.Update.MessageReactionUpdate
+          | tg.Update.PollAnswerUpdate
+          | tg.Update.ChatBoostUpdate
+      ? tg.User
+      : undefined
 
 function getUserFromAnySource<U extends tg.Update>(ctx: Context<U>) {
   if (ctx.callbackQuery) return ctx.callbackQuery.from
@@ -1612,13 +1614,14 @@ function getUserFromAnySource<U extends tg.Update>(ctx: Context<U>) {
   )
 }
 
-type GetMsgId<U extends tg.Update> = GetMsg<U> extends { message_id: number }
-  ? number
-  : U extends tg.Update.MessageReactionUpdate
-  ? number
-  : U extends tg.Update.MessageReactionCountUpdate
-  ? number
-  : undefined
+type GetMsgId<U extends tg.Update> =
+  GetMsg<U> extends { message_id: number }
+    ? number
+    : U extends tg.Update.MessageReactionUpdate
+      ? number
+      : U extends tg.Update.MessageReactionCountUpdate
+        ? number
+        : undefined
 
 function getMsgIdFromAnySource<U extends tg.Update>(ctx: Context<U>) {
   const msg = getMessageFromAnySource(ctx)
@@ -1626,13 +1629,14 @@ function getMsgIdFromAnySource<U extends tg.Update>(ctx: Context<U>) {
     ?.message_id as GetMsgId<U>
 }
 
-type GetText<U extends tg.Update> = GetMsg<U> extends tg.Message.TextMessage
-  ? string
-  : GetMsg<U> extends tg.Message
-  ? string | undefined
-  : U extends tg.Update.PollUpdate
-  ? string | undefined
-  : undefined
+type GetText<U extends tg.Update> =
+  GetMsg<U> extends tg.Message.TextMessage
+    ? string
+    : GetMsg<U> extends tg.Message
+      ? string | undefined
+      : U extends tg.Update.PollUpdate
+        ? string | undefined
+        : undefined
 
 function getTextAndEntitiesFromAnySource<U extends tg.Update>(ctx: Context<U>) {
   const msg = ctx.msg
@@ -1640,13 +1644,13 @@ function getTextAndEntitiesFromAnySource<U extends tg.Update>(ctx: Context<U>) {
   let text, entities
 
   if (msg) {
-    if ('text' in msg) (text = msg.text), (entities = msg.entities)
+    if ('text' in msg) ((text = msg.text), (entities = msg.entities))
     else if ('caption' in msg)
-      (text = msg.caption), (entities = msg.caption_entities)
+      ((text = msg.caption), (entities = msg.caption_entities))
     else if ('game' in msg)
-      (text = msg.game.text), (entities = msg.game.text_entities)
+      ((text = msg.game.text), (entities = msg.game.text_entities))
   } else if (ctx.poll)
-    (text = ctx.poll.explanation), (entities = ctx.poll.explanation_entities)
+    ((text = ctx.poll.explanation), (entities = ctx.poll.explanation_entities))
 
   return [text, entities] as const
 }


### PR DESCRIPTION
Fixes TypeScript error where isAccessible and has methods in Msg interface were missing type predicate return types, causing build failure.