### PR TITLE
fix: create new Error instead of mutating in redactToken

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -292,11 +292,13 @@ async function answerToWebhook(
 }
 
 function redactToken(error: Error): never {
-  error.message = error.message.replace(
+  const message = error.message.replace(
     /\/(bot|user)(\d+):[^/]+\//,
     '/$1$2:[REDACTED]/'
   )
-  throw error
+  const newError = new Error(message)
+  newError.stack = error.stack
+  throw newError
 }
 
 type Response = http.ServerResponse


### PR DESCRIPTION
Fix issue where redactToken was mutating the original error object and rethrowing it. Now creates a new Error to avoid potential side effects.