### PR TITLE
fix: serialize object-valued multipart fields such as reply_parameters

### DIFF
--- a/src/core/network/client.ts
+++ b/src/core/network/client.ts
@@ -220,7 +220,18 @@ async function attachFormValue(
       }),
     })
   }
-  return await attachFormMedia(form, value as InputFile, id, agent)
+  if (
+    value &&
+    typeof value === 'object' &&
+    ((hasProp(value, 'source') && typeof value.source !== 'undefined') ||
+      (hasProp(value, 'url') && typeof value.url !== 'undefined'))
+  ) {
+    return await attachFormMedia(form, value as InputFile, id, agent)
+  }
+  return form.addPart({
+    headers: { 'content-disposition': `form-data; name="${id}"` },
+    body: JSON.stringify(value),
+  })
 }
 
 async function attachFormMedia(


### PR DESCRIPTION
## Summary

Fixes a long-standing bug where `reply_parameters` (and other plain object fields) are **silently dropped** when Telegraf sends media via multipart/form-data.

This is the same root cause reported in #1970 and #2094. In `attachFormValue`, any object that was not a media-group item or `InputMedia` wrapper fell through to `attachFormMedia`, which only handles `{ url }` / `{ source }` attachments. Plain objects like `{ message_id: 2919 }` were discarded with no error.

**Reproduction (4.16.3):**

```ts
await bot.telegram.sendVideo(
  chatId,
  { url: 'https://example.com/video.mp4' },
  { reply_parameters: { message_id: 2919 } }
);
// video is sent, but NOT as a reply
```

`sendMessage` with the same `reply_parameters` works because it uses a JSON body.

## Fix

After handling known media shapes, only treat values with `url`/`source` as `InputFile` attachments. All other objects are JSON-serialized into the multipart form, which the Bot API accepts.

This is the same approach as #1992 (approved LGTM in 2024) and the relevant part of #2092, extracted as a minimal, reviewable change against `v4`.

## Test plan

- [x] `npm run build`
- [x] `npm test` (162 tests passed)
- [ ] Manual: `sendVideo` / `sendPhoto` with `{ url }` input and `reply_parameters` now replies correctly

Fixes #1970
Closes #2094

Related: #1992, #2092